### PR TITLE
Generator renaming fix

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1176,10 +1176,10 @@ pub fn get_events(
     }
 }
 
-pub fn compile_cdp_json(file_name: &str) -> (Vec<TokenStream>, Vec<TokenStream>) {
+pub fn compile_cdp_json(file_name: &str, commit: &str) -> (Vec<TokenStream>, Vec<TokenStream>) {
     let url = format!(
-        "https://raw.githubusercontent.com/ChromeDevTools/devtools-protocol/master/json/{}",
-        file_name
+        "https://raw.githubusercontent.com/ChromeDevTools/devtools-protocol/{}/json/{}",
+        commit, file_name
     );
 
     let json = reqwest::blocking::get(url)

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -73,7 +73,6 @@ fn tokenize_enum(enum_vec: &Vec<String>, enum_name: String) -> (Ident, TokenStre
                         .map(|s| {
                             let mut upper = s.to_string();
                             upper.first_uppercase();
-
                             upper
                         })
                         .collect::<Vec<String>>()
@@ -84,10 +83,14 @@ fn tokenize_enum(enum_vec: &Vec<String>, enum_name: String) -> (Ident, TokenStre
                     Ident::new(&e.to_case(Case::Pascal), Span::call_site())
                 };
             quote! {
+                // tend to use serde renaming to keep compatities
+                #[serde(rename = #e)]
                 #enum_type,
             }
         }).collect();
     let enum_name = Ident::new(&enum_name, Span::call_site());
+
+    /*
     // FIXME: Some special case not covered by rename-all
     let vec: Vec<&String> = enum_vec
         .iter()
@@ -118,11 +121,11 @@ fn tokenize_enum(enum_vec: &Vec<String>, enum_name: String) -> (Ident, TokenStre
                 #[serde(rename_all = "kebab-case")]
             }
         }
-    }
+    } */
 
     let typ_enum = quote! {
         #[derive(Deserialize,Serialize, Debug,Clone,PartialEq)]
-        #rename
+        // #rename
         pub enum #enum_name {
             #(#enum_tokens)*
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod compile;
 use crate::compile::compile_cdp_json;
 
 pub fn init() {
+    const CDP_COMMIT: &str = "15f524c8f5ce5b317ddcdf5e6f875d6eb8bdac88";
     let mut file = OpenOptions::new()
         .append(true)
         .create(true)
@@ -22,9 +23,13 @@ pub fn init() {
     file.sync_all().unwrap();
 
     if file.metadata().unwrap().len() <= 0 {
-        let (js_mods,js_events) = compile_cdp_json("./js_protocol.json");
+        let (js_mods,js_events) =
+            compile_cdp_json("./js_protocol.json", CDP_COMMIT);
 
-        let (browser_mods,browser_events) = compile_cdp_json("./browser_protocol.json");
+        let (browser_mods,browser_events) =
+            compile_cdp_json("./browser_protocol.json", CDP_COMMIT);
+
+        writeln!(file, "// Auto-generated from ChromeDevTools/devtools-protocol at commit {}", CDP_COMMIT).unwrap();
 
         let modv = quote! {
             pub mod cdp {
@@ -100,5 +105,13 @@ pub fn init() {
             .arg("./src/protocol.rs")
             .output()
             .unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test() {
+        crate::init();
     }
 }


### PR DESCRIPTION
Related: https://github.com/atroche/rust-headless-chrome/pull/309

Using `#[serde(rename = "...")]` to keep compatibility. But add tons of generated codes. (If it's unacceptable, I will fix it later. I don't know if serde renaming happened at compile time or runtime)

Current CDP version won't compile so I made a change for fetching certain cdp commit.

Also add a comment above `protocol.rs`