### PR TITLE
Make output formatting by rustfmt optional

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,9 @@ pub fn init() {
 
         writeln!(file, "{}", modv.to_string()).unwrap();
 
-        Command::new("rustfmt").arg(&out_file).output().unwrap();
+        if env::var_os("DO_NOT_FORMAT").is_none() {
+            Command::new("rustfmt").arg(&out_file).output().unwrap();
+        }
     }
 }
 


### PR DESCRIPTION
For CI-heavy systems, where installing `rustfmt` isn't an option.
This is useful for dependent crates, such as `headless_chrome`. 