### PR TITLE
:bug: Fix: Windows path separator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 protocol.rs
+.idea

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,9 @@ fn main() {
     if cfg!(feature = "offline") {
         let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     
+        #[cfg(target_os = "windows")]
+        let manifest_dir = manifest_dir.replace(r#"\"#,r#"\\"#);
+    
         let out_dir = env::var("OUT_DIR").unwrap();
         let dest_path = Path::new(&out_dir).join("path.rs");
     


### PR DESCRIPTION
On windows the path separator is `\` so it should be escaped too. 
Fix #12 