### PR TITLE
Support formatting with rustfmt not from PATH

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,11 @@ pub fn init() {
         writeln!(file, "{}", modv.to_string()).unwrap();
 
         if env::var_os("DO_NOT_FORMAT").is_none() {
-            Command::new("rustfmt").arg(&out_file).output().unwrap();
+            let mut rustfmt = match env::var_os("RUSTFMT") {
+                Some(rustfmt) => Command::new(rustfmt),
+                None => Command::new("rustfmt"),
+            };
+            rustfmt.arg(&out_file).output().unwrap();
         }
     }
 }


### PR DESCRIPTION
This makes it possible for hermetic monorepo build systems like Buck to ensure auto_generate_cdp produces a deterministic result, not depending on the user's ambient environment when they run the build.

Hermetic monorepos typically have all build tooling (rustc, rustfmt, buck, python, ld etc) checked into the repo, so that someone can checkout an arbitrary commit on any machine and immediately build the code without installing anything or messing with versions of things.

In this environment we'd want to generate (via [Reindeer](https://github.com/facebookincubator/reindeer)) something like the following, in which auto_generate_cdp ends up running the monorepo's build of rustfmt.

```starlark
rust_library(
    name = "auto_generate_cdp-0.4.4",
    srcs = glob(["vendor/auto_generate_cdp-0.4.4/src/**/*.rs"]),
    edition = "2018",
    features = ["offline"],
    deps = [
        ":convert_case-0.4.0",
        ":proc-macro2-1.0.69",
        ":quote-1.0.33",
        ":serde-1.0.192",
        ":serde_json-1.0.108",
        ":ureq-2.9.0",
    ],
)

rust_library(
    name = "headless_chrome-1.0.8",
    srcs = glob(["vendor/headless_chrome-1.0.8/src/**/*.rs"]),
    edition = "2021",
    env = {
        "OUT_DIR": "$(location :headless_chrome-1.0.8-build-script-run[out_dir])",
    },
    features = ["default", "offline"],
    deps = [
        ...
    ],
)
    
rust_binary(
    name = "headless_chrome-1.0.8-build-script-build",
    srcs = ["vendor/headless_chrome-1.0.8/build.rs"],
    edition = "2021",
    features = ["default", "offline"],
    deps = [
        ":auto_generate_cdp-0.4.4",
    ],
)

rust_buildscript_run(
    name = "headless_chrome-1.0.8-build-script-run",
    binary = ":headless_chrome-1.0.8-build-script-build",
    env = {
        "RUSTFMT": "$(exe //tools/third-party/rustfmt)",
    },
    features = ["default", "offline"],
)
```