### PR TITLE
Resolve noop_method_call warnings

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -381,7 +381,7 @@ fn get_types(
                         get_types(
                             p_type,
                             PropertyType::Element(typ_element),
-                            Some(typ_element.clone()),
+                            Some(typ_element),
                             types,
                             enums,
                             objects,
@@ -398,7 +398,7 @@ fn get_types(
                                 Some(p) => get_types(
                                     p.clone(),
                                     PropertyType::Param(property),
-                                    Some(typ_element.clone()),
+                                    Some(typ_element),
                                     types,
                                     enums,
                                     objects,
@@ -1357,7 +1357,7 @@ pub fn compile_cdp_json(file_name: &str, commit: &str) -> (Vec<TokenStream>, Vec
                 get_types(
                     type_element.type_type,
                     PropertyType::Element(type_element),
-                    Some(type_element.clone()),
+                    Some(type_element),
                     &mut types,
                     &mut enums,
                     &mut objects,


### PR DESCRIPTION
These warnings have newly appeared in Rust 1.73.0.

```console
warning: call to `.clone()` on a reference in this situation does nothing
   --> src/compile.rs:384:45
    |
384 | ...                   Some(typ_element.clone()),
    |                                       ^^^^^^^^ help: remove this redundant call
    |
    = note: the type `TypeElement` does not implement `Clone`, so calling `clone` on `&TypeElement` copies the reference, which does not do anything and can be removed
    = note: `#[warn(noop_method_call)]` on by default

warning: call to `.clone()` on a reference in this situation does nothing
   --> src/compile.rs:401:53
    |
401 | ...                   Some(typ_element.clone()),
    |                                       ^^^^^^^^ help: remove this redundant call
    |
    = note: the type `TypeElement` does not implement `Clone`, so calling `clone` on `&TypeElement` copies the reference, which does not do anything and can be removed

warning: call to `.clone()` on a reference in this situation does nothing
    --> src/compile.rs:1360:38
     |
1360 |                     Some(type_element.clone()),
     |                                      ^^^^^^^^ help: remove this redundant call
     |
     = note: the type `TypeElement` does not implement `Clone`, so calling `clone` on `&TypeElement` copies the reference, which does not do anything and can be removed

warning: `auto_generate_cdp` (lib) generated 3 warnings (run `cargo fix --lib -p auto_generate_cdp` to apply 3 suggestions)
```

`typ_element`'s type is `&TypeElement`. There is no `impl Clone for TypeElement`. So what `typ_element.clone()` is doing is really `(&type_element).clone()` with an autoref inserted, i.e. `<&&TypeElement as Clone>::clone(&typ_element)`, which produces a `&TypeElement` identical to what you started with.