### PR TITLE
Update to latest CDP release and fixes for generated protocol.rs

### DIFF
--- a/json/browser_protocol.json
+++ b/json/browser_protocol.json
@@ -210,6 +210,7 @@
                     "description": "Values of AXProperty name:\n- from 'busy' to 'roledescription': states which apply to every AX node\n- from 'live' to 'root': attributes which apply to nodes in live regions\n- from 'autocomplete' to 'valuetext': attributes which apply to widgets\n- from 'checked' to 'selected': states which apply to widgets\n- from 'activedescendant' to 'owns' - relationships between elements other than parent/child/sibling.",
                     "type": "string",
                     "enum": [
+                        "actions",
                         "busy",
                         "disabled",
                         "editable",
@@ -1048,7 +1049,9 @@
                         "ExcludeSamePartyCrossPartyContext",
                         "ExcludeDomainNonASCII",
                         "ExcludeThirdPartyCookieBlockedInFirstPartySet",
-                        "ExcludeThirdPartyPhaseout"
+                        "ExcludeThirdPartyPhaseout",
+                        "ExcludePortMismatch",
+                        "ExcludeSchemeMismatch"
                     ]
                 },
                 {
@@ -1066,7 +1069,9 @@
                         "WarnAttributeValueExceedsMaxSize",
                         "WarnDomainNonASCII",
                         "WarnThirdPartyPhaseout",
-                        "WarnCrossSiteRedirectDowngradeChangesInclusion"
+                        "WarnCrossSiteRedirectDowngradeChangesInclusion",
+                        "WarnDeprecationTrialMetadata",
+                        "WarnThirdPartyCookieHeuristic"
                     ]
                 },
                 {
@@ -1075,6 +1080,33 @@
                     "enum": [
                         "SetCookie",
                         "ReadCookie"
+                    ]
+                },
+                {
+                    "id": "InsightType",
+                    "description": "Represents the category of insight that a cookie issue falls under.",
+                    "type": "string",
+                    "enum": [
+                        "GitHubResource",
+                        "GracePeriod",
+                        "Heuristics"
+                    ]
+                },
+                {
+                    "id": "CookieIssueInsight",
+                    "description": "Information about the suggested solution to a cookie issue.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "type",
+                            "$ref": "InsightType"
+                        },
+                        {
+                            "name": "tableEntryUrl",
+                            "description": "Link to table entry in third-party cookie migration readiness list.",
+                            "optional": true,
+                            "type": "string"
+                        }
                     ]
                 },
                 {
@@ -1126,6 +1158,12 @@
                             "name": "request",
                             "optional": true,
                             "$ref": "AffectedRequest"
+                        },
+                        {
+                            "name": "insight",
+                            "description": "The recommended solution to the issue.",
+                            "optional": true,
+                            "$ref": "CookieIssueInsight"
                         }
                     ]
                 },
@@ -1223,7 +1261,8 @@
                         "CorpNotSameOriginAfterDefaultedToSameOriginByCoep",
                         "CorpNotSameOriginAfterDefaultedToSameOriginByDip",
                         "CorpNotSameOriginAfterDefaultedToSameOriginByCoepAndDip",
-                        "CorpNotSameSite"
+                        "CorpNotSameSite",
+                        "SRIMessageSignatureMismatch"
                     ]
                 },
                 {
@@ -1487,7 +1526,8 @@
                         "NoRegisterSourceHeader",
                         "NoRegisterTriggerHeader",
                         "NoRegisterOsSourceHeader",
-                        "NoRegisterOsTriggerHeader"
+                        "NoRegisterOsTriggerHeader",
+                        "NavigationRegistrationUniqueScopeAlreadySet"
                     ]
                 },
                 {
@@ -1777,7 +1817,7 @@
                         "ThirdPartyCookiesBlocked",
                         "NotSignedInWithIdp",
                         "MissingTransientUserActivation",
-                        "ReplacedByButtonMode",
+                        "ReplacedByActiveMode",
                         "InvalidFieldsSpecified",
                         "RelyingPartyOriginIsOpaque",
                         "TypeNotMatching"
@@ -2213,7 +2253,7 @@
                 },
                 {
                     "name": "getStorageItems",
-                    "description": "Gets data from extension storage in the given `area`. If `keys` is\nspecified, these are used to filter the result.",
+                    "description": "Gets data from extension storage in the given `storageArea`. If `keys` is\nspecified, these are used to filter the result.",
                     "parameters": [
                         {
                             "name": "id",
@@ -2238,6 +2278,67 @@
                     "returns": [
                         {
                             "name": "data",
+                            "type": "object"
+                        }
+                    ]
+                },
+                {
+                    "name": "removeStorageItems",
+                    "description": "Removes `keys` from extension storage in the given `storageArea`.",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "description": "ID of extension.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "storageArea",
+                            "description": "StorageArea to remove data from.",
+                            "$ref": "StorageArea"
+                        },
+                        {
+                            "name": "keys",
+                            "description": "Keys to remove.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "clearStorageItems",
+                    "description": "Clears extension storage in the given `storageArea`.",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "description": "ID of extension.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "storageArea",
+                            "description": "StorageArea to remove data from.",
+                            "$ref": "StorageArea"
+                        }
+                    ]
+                },
+                {
+                    "name": "setStorageItems",
+                    "description": "Sets `values` in extension storage in the given `storageArea`. The provided `values`\nwill be merged with existing values in the storage area.",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "description": "ID of extension.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "storageArea",
+                            "description": "StorageArea to set data in.",
+                            "$ref": "StorageArea"
+                        },
+                        {
+                            "name": "values",
+                            "description": "Values to set.",
                             "type": "object"
                         }
                     ]
@@ -2687,18 +2788,21 @@
                     "experimental": true,
                     "type": "string",
                     "enum": [
-                        "accessibilityEvents",
+                        "ar",
                         "audioCapture",
-                        "backgroundSync",
+                        "automaticFullscreen",
                         "backgroundFetch",
+                        "backgroundSync",
+                        "cameraPanTiltZoom",
                         "capturedSurfaceControl",
                         "clipboardReadWrite",
                         "clipboardSanitizedWrite",
                         "displayCapture",
                         "durableStorage",
-                        "flash",
                         "geolocation",
+                        "handTracking",
                         "idleDetection",
+                        "keyboardLock",
                         "localFonts",
                         "midi",
                         "midiSysex",
@@ -2706,15 +2810,19 @@
                         "notifications",
                         "paymentHandler",
                         "periodicBackgroundSync",
+                        "pointerLock",
                         "protectedMediaIdentifier",
                         "sensors",
-                        "storageAccess",
+                        "smartCard",
                         "speakerSelection",
+                        "storageAccess",
                         "topLevelStorageAccess",
                         "videoCapture",
-                        "videoCapturePanTiltZoom",
+                        "vr",
                         "wakeLockScreen",
                         "wakeLockSystem",
+                        "webAppInstallation",
+                        "webPrinting",
                         "windowManagement"
                     ]
                 },
@@ -3605,6 +3713,16 @@
                             "items": {
                                 "$ref": "CSSRuleType"
                             }
+                        },
+                        {
+                            "name": "startingStyles",
+                            "description": "@starting-style CSS at-rule array.\nThe array enumerates @starting-style at-rules starting with the innermost one, going outwards.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "CSSStartingStyle"
+                            }
                         }
                     ]
                 },
@@ -3619,7 +3737,8 @@
                         "ContainerRule",
                         "LayerRule",
                         "ScopeRule",
-                        "StyleRule"
+                        "StyleRule",
+                        "StartingStyleRule"
                     ]
                 },
                 {
@@ -3962,6 +4081,12 @@
                             "description": "Optional logical axes queried for the container.",
                             "optional": true,
                             "$ref": "DOM.LogicalAxes"
+                        },
+                        {
+                            "name": "queriesScrollState",
+                            "description": "true if the query contains scroll-state() queries.",
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ]
                 },
@@ -4031,6 +4156,26 @@
                             "description": "Layer name.",
                             "type": "string"
                         },
+                        {
+                            "name": "range",
+                            "description": "The associated rule header range in the enclosing stylesheet (if\navailable).",
+                            "optional": true,
+                            "$ref": "SourceRange"
+                        },
+                        {
+                            "name": "styleSheetId",
+                            "description": "Identifier of the stylesheet containing this object (if exists).",
+                            "optional": true,
+                            "$ref": "StyleSheetId"
+                        }
+                    ]
+                },
+                {
+                    "id": "CSSStartingStyle",
+                    "description": "CSS Starting Style at-rule descriptor.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
                         {
                             "name": "range",
                             "description": "The associated rule header range in the enclosing stylesheet (if\navailable).",
@@ -4212,26 +4357,6 @@
                             "name": "style",
                             "description": "Associated style declaration.",
                             "$ref": "CSSStyle"
-                        }
-                    ]
-                },
-                {
-                    "id": "CSSPositionFallbackRule",
-                    "description": "CSS position-fallback rule representation.",
-                    "deprecated": true,
-                    "type": "object",
-                    "properties": [
-                        {
-                            "name": "name",
-                            "$ref": "Value"
-                        },
-                        {
-                            "name": "tryRules",
-                            "description": "List of keyframes.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "CSSTryRule"
-                            }
                         }
                     ]
                 },
@@ -4664,16 +4789,6 @@
                             }
                         },
                         {
-                            "name": "cssPositionFallbackRules",
-                            "description": "A list of CSS position fallbacks matching this node.",
-                            "deprecated": true,
-                            "optional": true,
-                            "type": "array",
-                            "items": {
-                                "$ref": "CSSPositionFallbackRule"
-                            }
-                        },
-                        {
                             "name": "cssPositionTryRules",
                             "description": "A list of CSS @position-try rules matching this node, based on the position-try-fallbacks property.",
                             "optional": true,
@@ -4809,6 +4924,18 @@
                             "items": {
                                 "$ref": "SourceRange"
                             }
+                        }
+                    ]
+                },
+                {
+                    "name": "trackComputedStyleUpdatesForNode",
+                    "description": "Starts tracking the given node for the computed style updates\nand whenever the computed style is updated for node, it queues\na `computedStyleUpdated` event with throttling.\nThere can only be 1 node tracked for computed style updates\nso passing a new node id removes tracking from the previous node.\nPass `undefined` to disable tracking.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "nodeId",
+                            "optional": true,
+                            "$ref": "DOM.NodeId"
                         }
                     ]
                 },
@@ -5184,6 +5311,17 @@
                             "name": "styleSheetId",
                             "description": "Identifier of the removed stylesheet.",
                             "$ref": "StyleSheetId"
+                        }
+                    ]
+                },
+                {
+                    "name": "computedStyleUpdated",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "nodeId",
+                            "description": "The node id that has updated computed styles.",
+                            "$ref": "DOM.NodeId"
                         }
                     ]
                 }
@@ -5620,10 +5758,13 @@
                     "enum": [
                         "first-line",
                         "first-letter",
+                        "checkmark",
                         "before",
                         "after",
+                        "picker-icon",
                         "marker",
                         "backdrop",
+                        "column",
                         "selection",
                         "search-text",
                         "target-text",
@@ -5633,6 +5774,7 @@
                         "first-line-inherited",
                         "scroll-marker",
                         "scroll-marker-group",
+                        "scroll-button",
                         "scrollbar",
                         "scrollbar-thumb",
                         "scrollbar-button",
@@ -5645,7 +5787,11 @@
                         "view-transition-group",
                         "view-transition-image-pair",
                         "view-transition-old",
-                        "view-transition-new"
+                        "view-transition-new",
+                        "placeholder",
+                        "file-selector-button",
+                        "details-content",
+                        "picker"
                     ]
                 },
                 {
@@ -5895,6 +6041,30 @@
                             "name": "assignedSlot",
                             "optional": true,
                             "$ref": "BackendNode"
+                        },
+                        {
+                            "name": "isScrollable",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "id": "DetachedElementInfo",
+                    "description": "A structure to hold the top-level node of a detached tree and an array of its retained descendants.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "treeNode",
+                            "$ref": "Node"
+                        },
+                        {
+                            "name": "retainedNodeIds",
+                            "type": "array",
+                            "items": {
+                                "$ref": "NodeId"
+                            }
                         }
                     ]
                 },
@@ -6987,6 +7157,21 @@
                     ]
                 },
                 {
+                    "name": "getDetachedDomNodes",
+                    "description": "Returns list of detached nodes",
+                    "experimental": true,
+                    "returns": [
+                        {
+                            "name": "detachedNodes",
+                            "description": "The list of detached nodes",
+                            "type": "array",
+                            "items": {
+                                "$ref": "DetachedElementInfo"
+                            }
+                        }
+                    ]
+                },
+                {
                     "name": "setInspectedNode",
                     "description": "Enables console to refer to the node with given id via $x (see Command Line API for more details\n$x functions).",
                     "experimental": true,
@@ -7084,7 +7269,7 @@
                 },
                 {
                     "name": "getContainerForNode",
-                    "description": "Returns the query container of the given node based on container query\nconditions: containerName, physical, and logical axes. If no axes are\nprovided, the style container is returned, which is the direct parent or the\nclosest element with a matching container-name.",
+                    "description": "Returns the query container of the given node based on container query\nconditions: containerName, physical and logical axes, and whether it queries\nscroll-state. If no axes are provided and queriesScrollState is false, the\nstyle container is returned, which is the direct parent or the closest\nelement with a matching container-name.",
                     "experimental": true,
                     "parameters": [
                         {
@@ -7105,6 +7290,11 @@
                             "name": "logicalAxes",
                             "optional": true,
                             "$ref": "LogicalAxes"
+                        },
+                        {
+                            "name": "queriesScrollState",
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ],
                     "returns": [
@@ -7331,6 +7521,23 @@
                     "name": "topLayerElementsUpdated",
                     "description": "Called when top layer elements are changed.",
                     "experimental": true
+                },
+                {
+                    "name": "scrollableFlagUpdated",
+                    "description": "Fired when a node's scrollability state changes.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "nodeId",
+                            "description": "The id of the node.",
+                            "$ref": "DOM.NodeId"
+                        },
+                        {
+                            "name": "isScrollable",
+                            "description": "If the node is scrollable.",
+                            "type": "boolean"
+                        }
+                    ]
                 },
                 {
                     "name": "pseudoElementRemoved",
@@ -9068,7 +9275,6 @@
                         "gyroscope",
                         "linear-acceleration",
                         "magnetometer",
-                        "proximity",
                         "relative-orientation"
                     ]
                 },
@@ -12077,11 +12283,29 @@
                             "type": "number"
                         }
                     ]
+                },
+                {
+                    "id": "DOMCounter",
+                    "description": "DOM object counter data.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "description": "Object name. Note: object names should be presumed volatile and clients should not expect\nthe returned names to be consistent across runs.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "count",
+                            "description": "Object count.",
+                            "type": "integer"
+                        }
+                    ]
                 }
             ],
             "commands": [
                 {
                     "name": "getDOMCounters",
+                    "description": "Retruns current DOM object counters.",
                     "returns": [
                         {
                             "name": "documents",
@@ -12098,7 +12322,22 @@
                     ]
                 },
                 {
-                    "name": "prepareForLeakDetection"
+                    "name": "getDOMCountersForLeakDetection",
+                    "description": "Retruns DOM object counters after preparing renderer for leak detection.",
+                    "returns": [
+                        {
+                            "name": "counters",
+                            "description": "DOM object counters.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "DOMCounter"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "prepareForLeakDetection",
+                    "description": "Prepares for leak detection by terminating workers, stopping spellcheckers,\ndropping non-essential internal caches, running garbage collections, etc."
                 },
                 {
                     "name": "forciblyPurgeJavaScriptMemory",
@@ -12221,7 +12460,7 @@
                 },
                 {
                     "id": "RequestId",
-                    "description": "Unique request identifier.",
+                    "description": "Unique network request identifier.\nNote that this does not identify individual HTTP requests that are part of\na network request.",
                     "type": "string"
                 },
                 {
@@ -12723,7 +12962,8 @@
                         "corp-not-same-origin-after-defaulted-to-same-origin-by-coep",
                         "corp-not-same-origin-after-defaulted-to-same-origin-by-dip",
                         "corp-not-same-origin-after-defaulted-to-same-origin-by-coep-and-dip",
-                        "corp-not-same-site"
+                        "corp-not-same-site",
+                        "sri-message-signature-mismatch"
                     ]
                 },
                 {
@@ -13169,7 +13409,7 @@
                         },
                         {
                             "name": "stack",
-                            "description": "Initiator JavaScript stack trace, set for Script only.",
+                            "description": "Initiator JavaScript stack trace, set for Script only.\nRequires the Debugger domain to be enabled.",
                             "optional": true,
                             "$ref": "Runtime.StackTrace"
                         },
@@ -13365,7 +13605,9 @@
                         "SchemefulSameSiteLax",
                         "SchemefulSameSiteUnspecifiedTreatedAsLax",
                         "SamePartyFromCrossPartyContext",
-                        "NameValuePairExceedsMaxSize"
+                        "NameValuePairExceedsMaxSize",
+                        "PortMismatch",
+                        "SchemeMismatch"
                     ]
                 },
                 {
@@ -13378,11 +13620,11 @@
                         "UserSetting",
                         "TPCDMetadata",
                         "TPCDDeprecationTrial",
+                        "TopLevelTPCDDeprecationTrial",
                         "TPCDHeuristics",
                         "EnterprisePolicy",
                         "StorageAccess",
                         "TopLevelStorageAccess",
-                        "CorsOptIn",
                         "Scheme"
                     ]
                 },
@@ -16809,7 +17051,8 @@
                 },
                 {
                     "name": "setShowWebVitals",
-                    "description": "Request that backend shows an overlay with web vital metrics.",
+                    "description": "Deprecated, no longer has any effect.",
+                    "deprecated": true,
                     "parameters": [
                         {
                             "name": "show",
@@ -17056,15 +17299,19 @@
                         "clipboard-read",
                         "clipboard-write",
                         "compute-pressure",
+                        "controlled-frame",
                         "cross-origin-isolated",
                         "deferred-fetch",
+                        "deferred-fetch-minimal",
                         "digital-credentials-get",
                         "direct-sockets",
+                        "direct-sockets-private",
                         "display-capture",
                         "document-domain",
                         "encrypted-media",
                         "execution-while-out-of-viewport",
                         "execution-while-not-rendered",
+                        "fenced-unpartitioned-storage-read",
                         "focus-without-user-activation",
                         "fullscreen",
                         "frobulate",
@@ -17085,6 +17332,7 @@
                         "otp-credentials",
                         "payment",
                         "picture-in-picture",
+                        "popins",
                         "private-aggregation",
                         "private-state-token-issuance",
                         "private-state-token-redemption",
@@ -17105,6 +17353,7 @@
                         "usb",
                         "usb-unrestricted",
                         "vertical-scroll",
+                        "web-app-installation",
                         "web-printing",
                         "web-share",
                         "window-management",
@@ -17815,14 +18064,16 @@
                     "experimental": true,
                     "type": "string",
                     "enum": [
+                        "anchorClick",
                         "formSubmissionGet",
                         "formSubmissionPost",
                         "httpHeaderRefresh",
-                        "scriptInitiated",
+                        "initialFrameNavigation",
                         "metaTagRefresh",
+                        "other",
                         "pageBlockInterstitial",
                         "reload",
-                        "anchorClick"
+                        "scriptInitiated"
                     ]
                 },
                 {
@@ -18427,6 +18678,7 @@
                         "ContentWebUSB",
                         "ContentMediaSessionService",
                         "ContentScreenReader",
+                        "ContentDiscarded",
                         "EmbedderPopupBlockerTabHelper",
                         "EmbedderSafeBrowsingTriggeredPopupBlocker",
                         "EmbedderSafeBrowsingThreatDetails",
@@ -18442,7 +18694,8 @@
                         "EmbedderExtensionMessaging",
                         "EmbedderExtensionMessagingForOpenPort",
                         "EmbedderExtensionSentMessageToCachedFrame",
-                        "RequestedByWebViewClient"
+                        "RequestedByWebViewClient",
+                        "PostMessageByWebViewClient"
                     ]
                 },
                 {
@@ -19868,6 +20121,18 @@
                     ]
                 },
                 {
+                    "name": "frameSubtreeWillBeDetached",
+                    "description": "Fired before frame subtree is detached. Emitted before any frame of the\nsubtree is actually detached.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "frameId",
+                            "description": "Id of the frame that is the root of the subtree that will be detached.",
+                            "$ref": "FrameId"
+                        }
+                    ]
+                },
+                {
                     "name": "frameNavigated",
                     "description": "Fired once navigation of the frame has completed. Frame is now associated with the new loader.",
                     "parameters": [
@@ -20096,7 +20361,7 @@
                 },
                 {
                     "name": "lifecycleEvent",
-                    "description": "Fired for top level page lifecycle events such as navigation, load, paint, etc.",
+                    "description": "Fired for lifecycle events (navigation, load, paint, etc) in the current\ntarget (including local frames).",
                     "parameters": [
                         {
                             "name": "frameId",
@@ -20172,6 +20437,16 @@
                             "name": "url",
                             "description": "Frame's new url.",
                             "type": "string"
+                        },
+                        {
+                            "name": "navigationType",
+                            "description": "Navigation type",
+                            "type": "string",
+                            "enum": [
+                                "fragment",
+                                "historyApi",
+                                "other"
+                            ]
                         }
                     ]
                 },
@@ -21768,6 +22043,29 @@
                     ]
                 },
                 {
+                    "id": "AttributionScopesData",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "values",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "name": "limit",
+                            "description": "number instead of integer because not all uint32 can be represented by\nint",
+                            "type": "number"
+                        },
+                        {
+                            "name": "maxEventStates",
+                            "type": "number"
+                        }
+                    ]
+                },
+                {
                     "id": "AttributionReportingSourceRegistration",
                     "experimental": true,
                     "type": "object",
@@ -21850,6 +22148,15 @@
                         {
                             "name": "aggregatableDebugReportingConfig",
                             "$ref": "AttributionReportingAggregatableDebugReportingConfig"
+                        },
+                        {
+                            "name": "scopesData",
+                            "optional": true,
+                            "$ref": "AttributionScopesData"
+                        },
+                        {
+                            "name": "maxEventLevelReports",
+                            "type": "integer"
                         }
                     ]
                 },
@@ -21870,7 +22177,9 @@
                         "destinationBothLimitsReached",
                         "reportingOriginsPerSiteLimitReached",
                         "exceedsMaxChannelCapacity",
+                        "exceedsMaxScopesChannelCapacity",
                         "exceedsMaxTriggerStateCardinality",
+                        "exceedsMaxEventStatesLimit",
                         "destinationPerDayReportingLimitReached"
                     ]
                 },
@@ -22050,6 +22359,13 @@
                         {
                             "name": "aggregatableDebugReportingConfig",
                             "$ref": "AttributionReportingAggregatableDebugReportingConfig"
+                        },
+                        {
+                            "name": "scopes",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
                         }
                     ]
                 },
@@ -22092,6 +22408,7 @@
                         "excessiveReportingOrigins",
                         "noHistograms",
                         "insufficientBudget",
+                        "insufficientNamedBudget",
                         "noMatchingSourceFilterData",
                         "notRegistered",
                         "prohibitedByBrowserPolicy",
@@ -24259,7 +24576,7 @@
             "types": [
                 {
                     "id": "RequestId",
-                    "description": "Unique request identifier.",
+                    "description": "Unique request identifier.\nNote that this does not identify individual HTTP requests that are part of\na network request.",
                     "type": "string"
                 },
                 {
@@ -24723,7 +25040,8 @@
                     "enum": [
                         "suspended",
                         "running",
-                        "closed"
+                        "closed",
+                        "interrupted"
                     ]
                 },
                 {
@@ -25328,6 +25646,18 @@
                             "description": "Assertions returned by this credential will have the backup state (BS)\nflag set to this value. Defaults to the authenticator's\ndefaultBackupState value.",
                             "optional": true,
                             "type": "boolean"
+                        },
+                        {
+                            "name": "userName",
+                            "description": "The credential's user.name property. Equivalent to empty if not set.\nhttps://w3c.github.io/webauthn/#dom-publickeycredentialentity-name",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "userDisplayName",
+                            "description": "The credential's user.displayName property. Equivalent to empty if\nnot set.\nhttps://w3c.github.io/webauthn/#dom-publickeycredentialuserentity-displayname",
+                            "optional": true,
+                            "type": "string"
                         }
                     ]
                 }
@@ -25537,6 +25867,34 @@
                 {
                     "name": "credentialAdded",
                     "description": "Triggered when a credential is added to an authenticator.",
+                    "parameters": [
+                        {
+                            "name": "authenticatorId",
+                            "$ref": "AuthenticatorId"
+                        },
+                        {
+                            "name": "credential",
+                            "$ref": "Credential"
+                        }
+                    ]
+                },
+                {
+                    "name": "credentialDeleted",
+                    "description": "Triggered when a credential is deleted, e.g. through\nPublicKeyCredential.signalUnknownCredential().",
+                    "parameters": [
+                        {
+                            "name": "authenticatorId",
+                            "$ref": "AuthenticatorId"
+                        },
+                        {
+                            "name": "credentialId",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "credentialUpdated",
+                    "description": "Triggered when a credential is updated, e.g. through\nPublicKeyCredential.signalCurrentUserDetails().",
                     "parameters": [
                         {
                             "name": "authenticatorId",
@@ -25997,6 +26355,11 @@
                     ]
                 },
                 {
+                    "id": "PreloadPipelineId",
+                    "description": "Chrome manages different types of preloads together using a\nconcept of preloading pipeline. For example, if a site uses a\nSpeculationRules for prerender, Chrome first starts a prefetch and\nthen upgrades it to prerender.\n\nCDP events for them are emitted separately but they share\n`PreloadPipelineId`.",
+                    "type": "string"
+                },
+                {
                     "id": "PrerenderFinalStatus",
                     "description": "List of FinalStatus reasons for Prerender2.",
                     "type": "string",
@@ -26071,7 +26434,9 @@
                         "AllPrerenderingCanceled",
                         "WindowClosed",
                         "SlowNetwork",
-                        "OtherPrerenderedPageActivated"
+                        "OtherPrerenderedPageActivated",
+                        "V8OptimizerDisabled",
+                        "PrerenderFailedDuringPrefetch"
                     ]
                 },
                 {
@@ -26098,7 +26463,6 @@
                         "PrefetchFailedMIMENotSupported",
                         "PrefetchFailedNetError",
                         "PrefetchFailedNon2XX",
-                        "PrefetchFailedPerPageLimitExceeded",
                         "PrefetchEvictedAfterCandidateRemoved",
                         "PrefetchEvictedForNewerPrefetch",
                         "PrefetchHeldback",
@@ -26210,6 +26574,10 @@
                             "$ref": "PreloadingAttemptKey"
                         },
                         {
+                            "name": "pipelineId",
+                            "$ref": "PreloadPipelineId"
+                        },
+                        {
                             "name": "initiatingFrameId",
                             "description": "The frame id of the frame initiating prefetch.",
                             "$ref": "Page.FrameId"
@@ -26239,6 +26607,10 @@
                         {
                             "name": "key",
                             "$ref": "PreloadingAttemptKey"
+                        },
+                        {
+                            "name": "pipelineId",
+                            "$ref": "PreloadPipelineId"
                         },
                         {
                             "name": "status",
@@ -26682,6 +27054,155 @@
                             "name": "displayMode",
                             "optional": true,
                             "$ref": "DisplayMode"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "domain": "BluetoothEmulation",
+            "description": "This domain allows configuring virtual Bluetooth devices to test\nthe web-bluetooth API.",
+            "experimental": true,
+            "types": [
+                {
+                    "id": "CentralState",
+                    "description": "Indicates the various states of Central.",
+                    "type": "string",
+                    "enum": [
+                        "absent",
+                        "powered-off",
+                        "powered-on"
+                    ]
+                },
+                {
+                    "id": "ManufacturerData",
+                    "description": "Stores the manufacturer data",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "key",
+                            "description": "Company identifier\nhttps://bitbucket.org/bluetooth-SIG/public/src/main/assigned_numbers/company_identifiers/company_identifiers.yaml\nhttps://usb.org/developers",
+                            "type": "integer"
+                        },
+                        {
+                            "name": "data",
+                            "description": "Manufacturer-specific data (Encoded as a base64 string when passed over JSON)",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "ScanRecord",
+                    "description": "Stores the byte data of the advertisement packet sent by a Bluetooth device.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "uuids",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "name": "appearance",
+                            "description": "Stores the external appearance description of the device.",
+                            "optional": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "txPower",
+                            "description": "Stores the transmission power of a broadcasting device.",
+                            "optional": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "manufacturerData",
+                            "description": "Key is the company identifier and the value is an array of bytes of\nmanufacturer specific data.",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "ManufacturerData"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "ScanEntry",
+                    "description": "Stores the advertisement packet information that is sent by a Bluetooth device.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "deviceAddress",
+                            "type": "string"
+                        },
+                        {
+                            "name": "rssi",
+                            "type": "integer"
+                        },
+                        {
+                            "name": "scanRecord",
+                            "$ref": "ScanRecord"
+                        }
+                    ]
+                }
+            ],
+            "commands": [
+                {
+                    "name": "enable",
+                    "description": "Enable the BluetoothEmulation domain.",
+                    "parameters": [
+                        {
+                            "name": "state",
+                            "description": "State of the simulated central.",
+                            "$ref": "CentralState"
+                        }
+                    ]
+                },
+                {
+                    "name": "disable",
+                    "description": "Disable the BluetoothEmulation domain."
+                },
+                {
+                    "name": "simulatePreconnectedPeripheral",
+                    "description": "Simulates a peripheral with |address|, |name| and |knownServiceUuids|\nthat has already been connected to the system.",
+                    "parameters": [
+                        {
+                            "name": "address",
+                            "type": "string"
+                        },
+                        {
+                            "name": "name",
+                            "type": "string"
+                        },
+                        {
+                            "name": "manufacturerData",
+                            "type": "array",
+                            "items": {
+                                "$ref": "ManufacturerData"
+                            }
+                        },
+                        {
+                            "name": "knownServiceUuids",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "simulateAdvertisement",
+                    "description": "Simulates an advertisement packet described in |entry| being received by\nthe central.",
+                    "parameters": [
+                        {
+                            "name": "entry",
+                            "$ref": "ScanEntry"
                         }
                     ]
                 }

--- a/json/browser_protocol.json
+++ b/json/browser_protocol.json
@@ -106,7 +106,7 @@
                         },
                         {
                             "name": "nativeSource",
-                            "description": "The native markup source for this value, e.g. a <label> element.",
+                            "description": "The native markup source for this value, e.g. a `<label>` element.",
                             "optional": true,
                             "$ref": "AXValueNativeSourceType"
                         },
@@ -248,7 +248,8 @@
                         "errormessage",
                         "flowto",
                         "labelledby",
-                        "owns"
+                        "owns",
+                        "url"
                     ]
                 },
                 {
@@ -278,6 +279,12 @@
                         {
                             "name": "role",
                             "description": "This `Node`'s role, whether explicit or implicit.",
+                            "optional": true,
+                            "$ref": "AXValue"
+                        },
+                        {
+                            "name": "chromeRole",
+                            "description": "This `Node`'s Chrome raw role.",
                             "optional": true,
                             "$ref": "AXValue"
                         },
@@ -372,7 +379,7 @@
                         },
                         {
                             "name": "fetchRelatives",
-                            "description": "Whether to fetch this nodes ancestors, siblings and children. Defaults to true.",
+                            "description": "Whether to fetch this node's ancestors, siblings and children. Defaults to true.",
                             "optional": true,
                             "type": "boolean"
                         }
@@ -400,15 +407,8 @@
                             "type": "integer"
                         },
                         {
-                            "name": "max_depth",
-                            "description": "Deprecated. This parameter has been renamed to `depth`. If depth is not provided, max_depth will be used.",
-                            "deprecated": true,
-                            "optional": true,
-                            "type": "integer"
-                        },
-                        {
                             "name": "frameId",
-                            "description": "The frame for whose document the AX tree should be retrieved.\nIf omited, the root frame is used.",
+                            "description": "The frame for whose document the AX tree should be retrieved.\nIf omitted, the root frame is used.",
                             "optional": true,
                             "$ref": "Page.FrameId"
                         }
@@ -504,7 +504,7 @@
                 },
                 {
                     "name": "queryAXTree",
-                    "description": "Query a DOM node's accessibility subtree for accessible name and role.\nThis command computes the name and role for all nodes in the subtree, including those that are\nignored for accessibility, and returns those that mactch the specified name and role. If no DOM\nnode is specified, or the DOM node does not exist, the command returns an error. If neither\n`accessibleName` or `role` is specified, it returns all the accessibility nodes in the subtree.",
+                    "description": "Query a DOM node's accessibility subtree for accessible name and role.\nThis command computes the name and role for all nodes in the subtree, including those that are\nignored for accessibility, and returns those that match the specified name and role. If no DOM\nnode is specified, or the DOM node does not exist, the command returns an error. If neither\n`accessibleName` or `role` is specified, it returns all the accessibility nodes in the subtree.",
                     "experimental": true,
                     "parameters": [
                         {
@@ -620,7 +620,7 @@
                         },
                         {
                             "name": "startTime",
-                            "description": "`Animation`'s start time.",
+                            "description": "`Animation`'s start time.\nMilliseconds for time based animations and\npercentage [0 - 100] for scroll driven animations\n(i.e. when viewOrScrollTimeline exists).",
                             "type": "number"
                         },
                         {
@@ -649,6 +649,48 @@
                             "description": "A unique ID for `Animation` representing the sources that triggered this CSS\nanimation/transition.",
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "viewOrScrollTimeline",
+                            "description": "View or scroll timeline",
+                            "optional": true,
+                            "$ref": "ViewOrScrollTimeline"
+                        }
+                    ]
+                },
+                {
+                    "id": "ViewOrScrollTimeline",
+                    "description": "Timeline instance",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "sourceNodeId",
+                            "description": "Scroll container node",
+                            "optional": true,
+                            "$ref": "DOM.BackendNodeId"
+                        },
+                        {
+                            "name": "startOffset",
+                            "description": "Represents the starting scroll position of the timeline\nas a length offset in pixels from scroll origin.",
+                            "optional": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "endOffset",
+                            "description": "Represents the ending scroll position of the timeline\nas a length offset in pixels from scroll origin.",
+                            "optional": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "subjectNodeId",
+                            "description": "The element whose principal box's visibility in the\nscrollport defined the progress of the timeline.\nDoes not exist for animations with ScrollTimeline",
+                            "optional": true,
+                            "$ref": "DOM.BackendNodeId"
+                        },
+                        {
+                            "name": "axis",
+                            "description": "Orientation of the scroll",
+                            "$ref": "DOM.ScrollOrientation"
                         }
                     ]
                 },
@@ -679,7 +721,7 @@
                         },
                         {
                             "name": "duration",
-                            "description": "`AnimationEffect`'s iteration duration.",
+                            "description": "`AnimationEffect`'s iteration duration.\nMilliseconds for time based animations and\npercentage [0 - 100] for scroll driven animations\n(i.e. when viewOrScrollTimeline exists).",
                             "type": "number"
                         },
                         {
@@ -924,6 +966,17 @@
                             "$ref": "Animation"
                         }
                     ]
+                },
+                {
+                    "name": "animationUpdated",
+                    "description": "Event for animation that has been updated.",
+                    "parameters": [
+                        {
+                            "name": "animation",
+                            "description": "Animation that was updated.",
+                            "$ref": "Animation"
+                        }
+                    ]
                 }
             ]
         },
@@ -984,7 +1037,7 @@
                     ]
                 },
                 {
-                    "id": "SameSiteCookieExclusionReason",
+                    "id": "CookieExclusionReason",
                     "type": "string",
                     "enum": [
                         "ExcludeSameSiteUnspecifiedTreatedAsLax",
@@ -992,11 +1045,14 @@
                         "ExcludeSameSiteLax",
                         "ExcludeSameSiteStrict",
                         "ExcludeInvalidSameParty",
-                        "ExcludeSamePartyCrossPartyContext"
+                        "ExcludeSamePartyCrossPartyContext",
+                        "ExcludeDomainNonASCII",
+                        "ExcludeThirdPartyCookieBlockedInFirstPartySet",
+                        "ExcludeThirdPartyPhaseout"
                     ]
                 },
                 {
-                    "id": "SameSiteCookieWarningReason",
+                    "id": "CookieWarningReason",
                     "type": "string",
                     "enum": [
                         "WarnSameSiteUnspecifiedCrossSiteContext",
@@ -1006,11 +1062,15 @@
                         "WarnSameSiteStrictCrossDowngradeStrict",
                         "WarnSameSiteStrictCrossDowngradeLax",
                         "WarnSameSiteLaxCrossDowngradeStrict",
-                        "WarnSameSiteLaxCrossDowngradeLax"
+                        "WarnSameSiteLaxCrossDowngradeLax",
+                        "WarnAttributeValueExceedsMaxSize",
+                        "WarnDomainNonASCII",
+                        "WarnThirdPartyPhaseout",
+                        "WarnCrossSiteRedirectDowngradeChangesInclusion"
                     ]
                 },
                 {
-                    "id": "SameSiteCookieOperation",
+                    "id": "CookieOperation",
                     "type": "string",
                     "enum": [
                         "SetCookie",
@@ -1018,7 +1078,7 @@
                     ]
                 },
                 {
-                    "id": "SameSiteCookieIssueDetails",
+                    "id": "CookieIssueDetails",
                     "description": "This information is currently necessary, as the front-end has a difficult\ntime finding a specific cookie. With this, we can convey specific error\ninformation without the cookie.",
                     "type": "object",
                     "properties": [
@@ -1037,20 +1097,20 @@
                             "name": "cookieWarningReasons",
                             "type": "array",
                             "items": {
-                                "$ref": "SameSiteCookieWarningReason"
+                                "$ref": "CookieWarningReason"
                             }
                         },
                         {
                             "name": "cookieExclusionReasons",
                             "type": "array",
                             "items": {
-                                "$ref": "SameSiteCookieExclusionReason"
+                                "$ref": "CookieExclusionReason"
                             }
                         },
                         {
                             "name": "operation",
                             "description": "Optionally identifies the site-for-cookies and the cookie url, which\nmay be used by the front-end as additional context.",
-                            "$ref": "SameSiteCookieOperation"
+                            "$ref": "CookieOperation"
                         },
                         {
                             "name": "siteForCookies",
@@ -1082,6 +1142,7 @@
                     "id": "MixedContentResourceType",
                     "type": "string",
                     "enum": [
+                        "AttributionSrc",
                         "Audio",
                         "Beacon",
                         "CSPReport",
@@ -1093,6 +1154,7 @@
                         "Frame",
                         "Image",
                         "Import",
+                        "JSON",
                         "Manifest",
                         "Ping",
                         "PluginData",
@@ -1102,6 +1164,7 @@
                         "Script",
                         "ServiceWorker",
                         "SharedWorker",
+                        "SpeculationRules",
                         "Stylesheet",
                         "Track",
                         "Video",
@@ -1158,6 +1221,8 @@
                         "CoopSandboxedIFrameCannotNavigateToCoopPage",
                         "CorpNotSameOrigin",
                         "CorpNotSameOriginAfterDefaultedToSameOriginByCoep",
+                        "CorpNotSameOriginAfterDefaultedToSameOriginByDip",
+                        "CorpNotSameOriginAfterDefaultedToSameOriginByCoepAndDip",
                         "CorpNotSameSite"
                     ]
                 },
@@ -1327,47 +1392,6 @@
                     ]
                 },
                 {
-                    "id": "TwaQualityEnforcementViolationType",
-                    "type": "string",
-                    "enum": [
-                        "kHttpError",
-                        "kUnavailableOffline",
-                        "kDigitalAssetLinks"
-                    ]
-                },
-                {
-                    "id": "TrustedWebActivityIssueDetails",
-                    "type": "object",
-                    "properties": [
-                        {
-                            "name": "url",
-                            "description": "The url that triggers the violation.",
-                            "type": "string"
-                        },
-                        {
-                            "name": "violationType",
-                            "$ref": "TwaQualityEnforcementViolationType"
-                        },
-                        {
-                            "name": "httpStatusCode",
-                            "optional": true,
-                            "type": "integer"
-                        },
-                        {
-                            "name": "packageName",
-                            "description": "The package name of the Trusted Web Activity client app. This field is\nonly used when violation type is kDigitalAssetLinks.",
-                            "optional": true,
-                            "type": "string"
-                        },
-                        {
-                            "name": "signature",
-                            "description": "The signature of the Trusted Web Activity client app. This field is only\nused when violation type is kDigitalAssetLinks.",
-                            "optional": true,
-                            "type": "string"
-                        }
-                    ]
-                },
-                {
                     "id": "LowTextContrastIssueDetails",
                     "type": "object",
                     "properties": [
@@ -1445,27 +1469,64 @@
                     "type": "string",
                     "enum": [
                         "PermissionPolicyDisabled",
-                        "InvalidAttributionSourceEventId",
-                        "InvalidAttributionData",
-                        "AttributionSourceUntrustworthyOrigin",
-                        "AttributionUntrustworthyOrigin",
-                        "AttributionTriggerDataTooLarge",
-                        "AttributionEventSourceTriggerDataTooLarge"
+                        "UntrustworthyReportingOrigin",
+                        "InsecureContext",
+                        "InvalidHeader",
+                        "InvalidRegisterTriggerHeader",
+                        "SourceAndTriggerHeaders",
+                        "SourceIgnored",
+                        "TriggerIgnored",
+                        "OsSourceIgnored",
+                        "OsTriggerIgnored",
+                        "InvalidRegisterOsSourceHeader",
+                        "InvalidRegisterOsTriggerHeader",
+                        "WebAndOsHeaders",
+                        "NoWebOrOsSupport",
+                        "NavigationRegistrationWithoutTransientUserActivation",
+                        "InvalidInfoHeader",
+                        "NoRegisterSourceHeader",
+                        "NoRegisterTriggerHeader",
+                        "NoRegisterOsSourceHeader",
+                        "NoRegisterOsTriggerHeader"
+                    ]
+                },
+                {
+                    "id": "SharedDictionaryError",
+                    "type": "string",
+                    "enum": [
+                        "UseErrorCrossOriginNoCorsRequest",
+                        "UseErrorDictionaryLoadFailure",
+                        "UseErrorMatchingDictionaryNotUsed",
+                        "UseErrorUnexpectedContentDictionaryHeader",
+                        "WriteErrorCossOriginNoCorsRequest",
+                        "WriteErrorDisallowedBySettings",
+                        "WriteErrorExpiredResponse",
+                        "WriteErrorFeatureDisabled",
+                        "WriteErrorInsufficientResources",
+                        "WriteErrorInvalidMatchField",
+                        "WriteErrorInvalidStructuredHeader",
+                        "WriteErrorNavigationRequest",
+                        "WriteErrorNoMatchField",
+                        "WriteErrorNonListMatchDestField",
+                        "WriteErrorNonSecureContext",
+                        "WriteErrorNonStringIdField",
+                        "WriteErrorNonStringInMatchDestList",
+                        "WriteErrorNonStringMatchField",
+                        "WriteErrorNonTokenTypeField",
+                        "WriteErrorRequestAborted",
+                        "WriteErrorShuttingDown",
+                        "WriteErrorTooLongIdField",
+                        "WriteErrorUnsupportedType"
                     ]
                 },
                 {
                     "id": "AttributionReportingIssueDetails",
-                    "description": "Details for issues around \"Attribution Reporting API\" usage.\nExplainer: https://github.com/WICG/conversion-measurement-api",
+                    "description": "Details for issues around \"Attribution Reporting API\" usage.\nExplainer: https://github.com/WICG/attribution-reporting-api",
                     "type": "object",
                     "properties": [
                         {
                             "name": "violationType",
                             "$ref": "AttributionReportingIssueType"
-                        },
-                        {
-                            "name": "frame",
-                            "optional": true,
-                            "$ref": "AffectedFrame"
                         },
                         {
                             "name": "request",
@@ -1514,6 +1575,7 @@
                 },
                 {
                     "id": "NavigatorUserAgentIssueDetails",
+                    "deprecated": true,
                     "type": "object",
                     "properties": [
                         {
@@ -1528,24 +1590,16 @@
                     ]
                 },
                 {
-                    "id": "WasmCrossOriginModuleSharingIssueDetails",
+                    "id": "SharedDictionaryIssueDetails",
                     "type": "object",
                     "properties": [
                         {
-                            "name": "wasmModuleUrl",
-                            "type": "string"
+                            "name": "sharedDictionaryError",
+                            "$ref": "SharedDictionaryError"
                         },
                         {
-                            "name": "sourceOrigin",
-                            "type": "string"
-                        },
-                        {
-                            "name": "targetOrigin",
-                            "type": "string"
-                        },
-                        {
-                            "name": "isWarning",
-                            "type": "boolean"
+                            "name": "request",
+                            "$ref": "AffectedRequest"
                         }
                     ]
                 },
@@ -1553,7 +1607,17 @@
                     "id": "GenericIssueErrorType",
                     "type": "string",
                     "enum": [
-                        "CrossOriginPortalPostMessageError"
+                        "FormLabelForNameError",
+                        "FormDuplicateIdForInputError",
+                        "FormInputWithNoLabelError",
+                        "FormAutocompleteAttributeEmptyError",
+                        "FormEmptyIdAndNameAttributesForInputError",
+                        "FormAriaLabelledByToNonExistingId",
+                        "FormInputAssignedAutocompleteValueToIdOrNameAttributeError",
+                        "FormLabelHasNeitherForNorNestedInput",
+                        "FormLabelForMatchesNonExistingIdError",
+                        "FormInputHasWrongButWellIntendedAutocompleteValueError",
+                        "ResponseWasBlockedByORB"
                     ]
                 },
                 {
@@ -1570,12 +1634,27 @@
                             "name": "frameId",
                             "optional": true,
                             "$ref": "Page.FrameId"
+                        },
+                        {
+                            "name": "violatingNodeId",
+                            "optional": true,
+                            "$ref": "DOM.BackendNodeId"
+                        },
+                        {
+                            "name": "violatingNodeAttribute",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "request",
+                            "optional": true,
+                            "$ref": "AffectedRequest"
                         }
                     ]
                 },
                 {
                     "id": "DeprecationIssueDetails",
-                    "description": "This issue tracks information needed to print a deprecation message.\nThe formatting is inherited from the old console.log version, see more at:\nhttps://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/frame/deprecation.cc\nTODO(crbug.com/1264960): Re-work format to add i18n support per:\nhttps://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/devtools_protocol/README.md",
+                    "description": "This issue tracks information needed to print a deprecation message.\nhttps://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/frame/third_party/blink/renderer/core/frame/deprecation/README.md",
                     "type": "object",
                     "properties": [
                         {
@@ -1588,9 +1667,243 @@
                             "$ref": "SourceCodeLocation"
                         },
                         {
-                            "name": "message",
-                            "description": "The content of the deprecation issue (this won't be translated),\ne.g. \"window.inefficientLegacyStorageMethod will be removed in M97,\naround January 2022. Please use Web Storage or Indexed Database\ninstead. This standard was abandoned in January, 1970. See\nhttps://www.chromestatus.com/feature/5684870116278272 for more details.\"",
-                            "deprecated": true,
+                            "name": "type",
+                            "description": "One of the deprecation names from third_party/blink/renderer/core/frame/deprecation/deprecation.json5",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "BounceTrackingIssueDetails",
+                    "description": "This issue warns about sites in the redirect chain of a finished navigation\nthat may be flagged as trackers and have their state cleared if they don't\nreceive a user interaction. Note that in this context 'site' means eTLD+1.\nFor example, if the URL `https://example.test:80/bounce` was in the\nredirect chain, the site reported would be `example.test`.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "trackingSites",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "CookieDeprecationMetadataIssueDetails",
+                    "description": "This issue warns about third-party sites that are accessing cookies on the\ncurrent page, and have been permitted due to having a global metadata grant.\nNote that in this context 'site' means eTLD+1. For example, if the URL\n`https://example.test:80/web_page` was accessing cookies, the site reported\nwould be `example.test`.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "allowedSites",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "name": "optOutPercentage",
+                            "type": "number"
+                        },
+                        {
+                            "name": "isOptOutTopLevel",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "operation",
+                            "$ref": "CookieOperation"
+                        }
+                    ]
+                },
+                {
+                    "id": "ClientHintIssueReason",
+                    "type": "string",
+                    "enum": [
+                        "MetaTagAllowListInvalidOrigin",
+                        "MetaTagModifiedHTML"
+                    ]
+                },
+                {
+                    "id": "FederatedAuthRequestIssueDetails",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "federatedAuthRequestIssueReason",
+                            "$ref": "FederatedAuthRequestIssueReason"
+                        }
+                    ]
+                },
+                {
+                    "id": "FederatedAuthRequestIssueReason",
+                    "description": "Represents the failure reason when a federated authentication reason fails.\nShould be updated alongside RequestIdTokenStatus in\nthird_party/blink/public/mojom/devtools/inspector_issue.mojom to include\nall cases except for success.",
+                    "type": "string",
+                    "enum": [
+                        "ShouldEmbargo",
+                        "TooManyRequests",
+                        "WellKnownHttpNotFound",
+                        "WellKnownNoResponse",
+                        "WellKnownInvalidResponse",
+                        "WellKnownListEmpty",
+                        "WellKnownInvalidContentType",
+                        "ConfigNotInWellKnown",
+                        "WellKnownTooBig",
+                        "ConfigHttpNotFound",
+                        "ConfigNoResponse",
+                        "ConfigInvalidResponse",
+                        "ConfigInvalidContentType",
+                        "ClientMetadataHttpNotFound",
+                        "ClientMetadataNoResponse",
+                        "ClientMetadataInvalidResponse",
+                        "ClientMetadataInvalidContentType",
+                        "IdpNotPotentiallyTrustworthy",
+                        "DisabledInSettings",
+                        "DisabledInFlags",
+                        "ErrorFetchingSignin",
+                        "InvalidSigninResponse",
+                        "AccountsHttpNotFound",
+                        "AccountsNoResponse",
+                        "AccountsInvalidResponse",
+                        "AccountsListEmpty",
+                        "AccountsInvalidContentType",
+                        "IdTokenHttpNotFound",
+                        "IdTokenNoResponse",
+                        "IdTokenInvalidResponse",
+                        "IdTokenIdpErrorResponse",
+                        "IdTokenCrossSiteIdpErrorResponse",
+                        "IdTokenInvalidRequest",
+                        "IdTokenInvalidContentType",
+                        "ErrorIdToken",
+                        "Canceled",
+                        "RpPageNotVisible",
+                        "SilentMediationFailure",
+                        "ThirdPartyCookiesBlocked",
+                        "NotSignedInWithIdp",
+                        "MissingTransientUserActivation",
+                        "ReplacedByButtonMode",
+                        "InvalidFieldsSpecified",
+                        "RelyingPartyOriginIsOpaque",
+                        "TypeNotMatching"
+                    ]
+                },
+                {
+                    "id": "FederatedAuthUserInfoRequestIssueDetails",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "federatedAuthUserInfoRequestIssueReason",
+                            "$ref": "FederatedAuthUserInfoRequestIssueReason"
+                        }
+                    ]
+                },
+                {
+                    "id": "FederatedAuthUserInfoRequestIssueReason",
+                    "description": "Represents the failure reason when a getUserInfo() call fails.\nShould be updated alongside FederatedAuthUserInfoRequestResult in\nthird_party/blink/public/mojom/devtools/inspector_issue.mojom.",
+                    "type": "string",
+                    "enum": [
+                        "NotSameOrigin",
+                        "NotIframe",
+                        "NotPotentiallyTrustworthy",
+                        "NoApiPermission",
+                        "NotSignedInWithIdp",
+                        "NoAccountSharingPermission",
+                        "InvalidConfigOrWellKnown",
+                        "InvalidAccountsResponse",
+                        "NoReturningUserFromFetchedAccounts"
+                    ]
+                },
+                {
+                    "id": "ClientHintIssueDetails",
+                    "description": "This issue tracks client hints related issues. It's used to deprecate old\nfeatures, encourage the use of new ones, and provide general guidance.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "sourceCodeLocation",
+                            "$ref": "SourceCodeLocation"
+                        },
+                        {
+                            "name": "clientHintIssueReason",
+                            "$ref": "ClientHintIssueReason"
+                        }
+                    ]
+                },
+                {
+                    "id": "FailedRequestInfo",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "url",
+                            "description": "The URL that failed to load.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "failureMessage",
+                            "description": "The failure message for the failed request.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "requestId",
+                            "optional": true,
+                            "$ref": "Network.RequestId"
+                        }
+                    ]
+                },
+                {
+                    "id": "StyleSheetLoadingIssueReason",
+                    "type": "string",
+                    "enum": [
+                        "LateImportRule",
+                        "RequestFailed"
+                    ]
+                },
+                {
+                    "id": "StylesheetLoadingIssueDetails",
+                    "description": "This issue warns when a referenced stylesheet couldn't be loaded.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "sourceCodeLocation",
+                            "description": "Source code position that referenced the failing stylesheet.",
+                            "$ref": "SourceCodeLocation"
+                        },
+                        {
+                            "name": "styleSheetLoadingIssueReason",
+                            "description": "Reason why the stylesheet couldn't be loaded.",
+                            "$ref": "StyleSheetLoadingIssueReason"
+                        },
+                        {
+                            "name": "failedRequestInfo",
+                            "description": "Contains additional info when the failure was due to a request.",
+                            "optional": true,
+                            "$ref": "FailedRequestInfo"
+                        }
+                    ]
+                },
+                {
+                    "id": "PropertyRuleIssueReason",
+                    "type": "string",
+                    "enum": [
+                        "InvalidSyntax",
+                        "InvalidInitialValue",
+                        "InvalidInherits",
+                        "InvalidName"
+                    ]
+                },
+                {
+                    "id": "PropertyRuleIssueDetails",
+                    "description": "This issue warns about errors in property rules that lead to property\nregistrations being ignored.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "sourceCodeLocation",
+                            "description": "Source code position of the property rule.",
+                            "$ref": "SourceCodeLocation"
+                        },
+                        {
+                            "name": "propertyRuleIssueReason",
+                            "description": "Reason why the property rule was discarded.",
+                            "$ref": "PropertyRuleIssueReason"
+                        },
+                        {
+                            "name": "propertyValue",
+                            "description": "The value of the property rule property that failed to parse",
                             "optional": true,
                             "type": "string"
                         }
@@ -1601,21 +1914,27 @@
                     "description": "A unique identifier for the type of issue. Each type may use one of the\noptional fields in InspectorIssueDetails to convey more specific\ninformation about the kind of issue.",
                     "type": "string",
                     "enum": [
-                        "SameSiteCookieIssue",
+                        "CookieIssue",
                         "MixedContentIssue",
                         "BlockedByResponseIssue",
                         "HeavyAdIssue",
                         "ContentSecurityPolicyIssue",
                         "SharedArrayBufferIssue",
-                        "TrustedWebActivityIssue",
                         "LowTextContrastIssue",
                         "CorsIssue",
                         "AttributionReportingIssue",
                         "QuirksModeIssue",
                         "NavigatorUserAgentIssue",
-                        "WasmCrossOriginModuleSharingIssue",
                         "GenericIssue",
-                        "DeprecationIssue"
+                        "DeprecationIssue",
+                        "ClientHintIssue",
+                        "FederatedAuthRequestIssue",
+                        "BounceTrackingIssue",
+                        "CookieDeprecationMetadataIssue",
+                        "StylesheetLoadingIssue",
+                        "FederatedAuthUserInfoRequestIssue",
+                        "PropertyRuleIssue",
+                        "SharedDictionaryIssue"
                     ]
                 },
                 {
@@ -1624,9 +1943,9 @@
                     "type": "object",
                     "properties": [
                         {
-                            "name": "sameSiteCookieIssueDetails",
+                            "name": "cookieIssueDetails",
                             "optional": true,
-                            "$ref": "SameSiteCookieIssueDetails"
+                            "$ref": "CookieIssueDetails"
                         },
                         {
                             "name": "mixedContentIssueDetails",
@@ -1654,11 +1973,6 @@
                             "$ref": "SharedArrayBufferIssueDetails"
                         },
                         {
-                            "name": "twaQualityEnforcementDetails",
-                            "optional": true,
-                            "$ref": "TrustedWebActivityIssueDetails"
-                        },
-                        {
                             "name": "lowTextContrastIssueDetails",
                             "optional": true,
                             "$ref": "LowTextContrastIssueDetails"
@@ -1680,13 +1994,9 @@
                         },
                         {
                             "name": "navigatorUserAgentIssueDetails",
+                            "deprecated": true,
                             "optional": true,
                             "$ref": "NavigatorUserAgentIssueDetails"
-                        },
-                        {
-                            "name": "wasmCrossOriginModuleSharingIssue",
-                            "optional": true,
-                            "$ref": "WasmCrossOriginModuleSharingIssueDetails"
                         },
                         {
                             "name": "genericIssueDetails",
@@ -1697,6 +2007,46 @@
                             "name": "deprecationIssueDetails",
                             "optional": true,
                             "$ref": "DeprecationIssueDetails"
+                        },
+                        {
+                            "name": "clientHintIssueDetails",
+                            "optional": true,
+                            "$ref": "ClientHintIssueDetails"
+                        },
+                        {
+                            "name": "federatedAuthRequestIssueDetails",
+                            "optional": true,
+                            "$ref": "FederatedAuthRequestIssueDetails"
+                        },
+                        {
+                            "name": "bounceTrackingIssueDetails",
+                            "optional": true,
+                            "$ref": "BounceTrackingIssueDetails"
+                        },
+                        {
+                            "name": "cookieDeprecationMetadataIssueDetails",
+                            "optional": true,
+                            "$ref": "CookieDeprecationMetadataIssueDetails"
+                        },
+                        {
+                            "name": "stylesheetLoadingIssueDetails",
+                            "optional": true,
+                            "$ref": "StylesheetLoadingIssueDetails"
+                        },
+                        {
+                            "name": "propertyRuleIssueDetails",
+                            "optional": true,
+                            "$ref": "PropertyRuleIssueDetails"
+                        },
+                        {
+                            "name": "federatedAuthUserInfoRequestIssueDetails",
+                            "optional": true,
+                            "$ref": "FederatedAuthUserInfoRequestIssueDetails"
+                        },
+                        {
+                            "name": "sharedDictionaryIssueDetails",
+                            "optional": true,
+                            "$ref": "SharedDictionaryIssueDetails"
                         }
                     ]
                 },
@@ -1798,6 +2148,19 @@
                             "type": "boolean"
                         }
                     ]
+                },
+                {
+                    "name": "checkFormsIssues",
+                    "description": "Runs the form issues check for the target page. Found issues are reported\nusing Audits.issueAdded event.",
+                    "returns": [
+                        {
+                            "name": "formIssues",
+                            "type": "array",
+                            "items": {
+                                "$ref": "GenericIssueDetails"
+                            }
+                        }
+                    ]
                 }
             ],
             "events": [
@@ -1809,6 +2172,293 @@
                             "$ref": "InspectorIssue"
                         }
                     ]
+                }
+            ]
+        },
+        {
+            "domain": "Extensions",
+            "description": "Defines commands and events for browser extensions.",
+            "experimental": true,
+            "types": [
+                {
+                    "id": "StorageArea",
+                    "description": "Storage areas.",
+                    "type": "string",
+                    "enum": [
+                        "session",
+                        "local",
+                        "sync",
+                        "managed"
+                    ]
+                }
+            ],
+            "commands": [
+                {
+                    "name": "loadUnpacked",
+                    "description": "Installs an unpacked extension from the filesystem similar to\n--load-extension CLI flags. Returns extension ID once the extension\nhas been installed. Available if the client is connected using the\n--remote-debugging-pipe flag and the --enable-unsafe-extension-debugging\nflag is set.",
+                    "parameters": [
+                        {
+                            "name": "path",
+                            "description": "Absolute file path.",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "id",
+                            "description": "Extension id.",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "getStorageItems",
+                    "description": "Gets data from extension storage in the given `area`. If `keys` is\nspecified, these are used to filter the result.",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "description": "ID of extension.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "storageArea",
+                            "description": "StorageArea to retrieve data from.",
+                            "$ref": "StorageArea"
+                        },
+                        {
+                            "name": "keys",
+                            "description": "Keys to retrieve.",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "data",
+                            "type": "object"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "domain": "Autofill",
+            "description": "Defines commands and events for Autofill.",
+            "experimental": true,
+            "types": [
+                {
+                    "id": "CreditCard",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "number",
+                            "description": "16-digit credit card number.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "name",
+                            "description": "Name of the credit card owner.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "expiryMonth",
+                            "description": "2-digit expiry month.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "expiryYear",
+                            "description": "4-digit expiry year.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "cvc",
+                            "description": "3-digit card verification code.",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "AddressField",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "description": "address field name, for example GIVEN_NAME.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "value",
+                            "description": "address field value, for example Jon Doe.",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "AddressFields",
+                    "description": "A list of address fields.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "fields",
+                            "type": "array",
+                            "items": {
+                                "$ref": "AddressField"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "Address",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "fields",
+                            "description": "fields and values defining an address.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "AddressField"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "AddressUI",
+                    "description": "Defines how an address can be displayed like in chrome://settings/addresses.\nAddress UI is a two dimensional array, each inner array is an \"address information line\", and when rendered in a UI surface should be displayed as such.\nThe following address UI for instance:\n[[{name: \"GIVE_NAME\", value: \"Jon\"}, {name: \"FAMILY_NAME\", value: \"Doe\"}], [{name: \"CITY\", value: \"Munich\"}, {name: \"ZIP\", value: \"81456\"}]]\nshould allow the receiver to render:\nJon Doe\nMunich 81456",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "addressFields",
+                            "description": "A two dimension array containing the representation of values from an address profile.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "AddressFields"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "FillingStrategy",
+                    "description": "Specified whether a filled field was done so by using the html autocomplete attribute or autofill heuristics.",
+                    "type": "string",
+                    "enum": [
+                        "autocompleteAttribute",
+                        "autofillInferred"
+                    ]
+                },
+                {
+                    "id": "FilledField",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "htmlType",
+                            "description": "The type of the field, e.g text, password etc.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "id",
+                            "description": "the html id",
+                            "type": "string"
+                        },
+                        {
+                            "name": "name",
+                            "description": "the html name",
+                            "type": "string"
+                        },
+                        {
+                            "name": "value",
+                            "description": "the field value",
+                            "type": "string"
+                        },
+                        {
+                            "name": "autofillType",
+                            "description": "The actual field type, e.g FAMILY_NAME",
+                            "type": "string"
+                        },
+                        {
+                            "name": "fillingStrategy",
+                            "description": "The filling strategy",
+                            "$ref": "FillingStrategy"
+                        },
+                        {
+                            "name": "frameId",
+                            "description": "The frame the field belongs to",
+                            "$ref": "Page.FrameId"
+                        },
+                        {
+                            "name": "fieldId",
+                            "description": "The form field's DOM node",
+                            "$ref": "DOM.BackendNodeId"
+                        }
+                    ]
+                }
+            ],
+            "events": [
+                {
+                    "name": "addressFormFilled",
+                    "description": "Emitted when an address form is filled.",
+                    "parameters": [
+                        {
+                            "name": "filledFields",
+                            "description": "Information about the fields that were filled",
+                            "type": "array",
+                            "items": {
+                                "$ref": "FilledField"
+                            }
+                        },
+                        {
+                            "name": "addressUi",
+                            "description": "An UI representation of the address used to fill the form.\nConsists of a 2D array where each child represents an address/profile line.",
+                            "$ref": "AddressUI"
+                        }
+                    ]
+                }
+            ],
+            "commands": [
+                {
+                    "name": "trigger",
+                    "description": "Trigger autofill on a form identified by the fieldId.\nIf the field and related form cannot be autofilled, returns an error.",
+                    "parameters": [
+                        {
+                            "name": "fieldId",
+                            "description": "Identifies a field that serves as an anchor for autofill.",
+                            "$ref": "DOM.BackendNodeId"
+                        },
+                        {
+                            "name": "frameId",
+                            "description": "Identifies the frame that field belongs to.",
+                            "optional": true,
+                            "$ref": "Page.FrameId"
+                        },
+                        {
+                            "name": "card",
+                            "description": "Credit card information to fill out the form. Credit card data is not saved.",
+                            "$ref": "CreditCard"
+                        }
+                    ]
+                },
+                {
+                    "name": "setAddresses",
+                    "description": "Set addresses so that developers can verify their forms implementation.",
+                    "parameters": [
+                        {
+                            "name": "addresses",
+                            "type": "array",
+                            "items": {
+                                "$ref": "Address"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "disable",
+                    "description": "Disables autofill domain notifications."
+                },
+                {
+                    "name": "enable",
+                    "description": "Enables autofill domain notifications."
                 }
             ]
         },
@@ -1886,6 +2536,11 @@
                             "items": {
                                 "$ref": "EventMetadata"
                             }
+                        },
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key this event belongs to.",
+                            "type": "string"
                         }
                     ]
                 }
@@ -2036,12 +2691,15 @@
                         "audioCapture",
                         "backgroundSync",
                         "backgroundFetch",
+                        "capturedSurfaceControl",
                         "clipboardReadWrite",
                         "clipboardSanitizedWrite",
                         "displayCapture",
                         "durableStorage",
                         "flash",
                         "geolocation",
+                        "idleDetection",
+                        "localFonts",
                         "midi",
                         "midiSysex",
                         "nfc",
@@ -2050,11 +2708,14 @@
                         "periodicBackgroundSync",
                         "protectedMediaIdentifier",
                         "sensors",
+                        "storageAccess",
+                        "speakerSelection",
+                        "topLevelStorageAccess",
                         "videoCapture",
                         "videoCapturePanTiltZoom",
-                        "idleDetection",
                         "wakeLockScreen",
-                        "wakeLockSystem"
+                        "wakeLockSystem",
+                        "windowManagement"
                     ]
                 },
                 {
@@ -2069,7 +2730,7 @@
                 },
                 {
                     "id": "PermissionDescriptor",
-                    "description": "Definition of PermissionDescriptor defined in the Permissions API:\nhttps://w3c.github.io/permissions/#dictdef-permissiondescriptor.",
+                    "description": "Definition of PermissionDescriptor defined in the Permissions API:\nhttps://w3c.github.io/permissions/#dom-permissiondescriptor.",
                     "experimental": true,
                     "type": "object",
                     "properties": [
@@ -2093,6 +2754,12 @@
                         {
                             "name": "allowWithoutSanitization",
                             "description": "For \"clipboard\" permission, may specify allowWithoutSanitization.",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "allowWithoutGesture",
+                            "description": "For \"fullscreen\" permission, must specify allowWithoutGesture:true.",
                             "optional": true,
                             "type": "boolean"
                         },
@@ -2228,7 +2895,6 @@
                 {
                     "name": "resetPermissions",
                     "description": "Reset all permission management for all origins.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "browserContextId",
@@ -2245,7 +2911,7 @@
                     "parameters": [
                         {
                             "name": "behavior",
-                            "description": "Whether to allow all or deny all download requests, or use default Chrome behavior if\navailable (otherwise deny). |allowAndName| allows download and names files according to\ntheir dowmload guids.",
+                            "description": "Whether to allow all or deny all download requests, or use default Chrome behavior if\navailable (otherwise deny). |allowAndName| allows download and names files according to\ntheir download guids.",
                             "type": "string",
                             "enum": [
                                 "deny",
@@ -2365,7 +3031,7 @@
                         },
                         {
                             "name": "delta",
-                            "description": "If true, retrieve delta since last call.",
+                            "description": "If true, retrieve delta since last delta call.",
                             "optional": true,
                             "type": "boolean"
                         }
@@ -2393,7 +3059,7 @@
                         },
                         {
                             "name": "delta",
-                            "description": "If true, retrieve delta since last call.",
+                            "description": "If true, retrieve delta since last delta call.",
                             "optional": true,
                             "type": "boolean"
                         }
@@ -2495,6 +3161,16 @@
                             "$ref": "BrowserCommandId"
                         }
                     ]
+                },
+                {
+                    "name": "addPrivacySandboxEnrollmentOverride",
+                    "description": "Allows a site to use privacy sandbox features that require enrollment\nwithout the site actually being enrolled. Only supported on page targets.",
+                    "parameters": [
+                        {
+                            "name": "url",
+                            "type": "string"
+                        }
+                    ]
                 }
             ],
             "events": [
@@ -2594,6 +3270,12 @@
                             "$ref": "DOM.PseudoType"
                         },
                         {
+                            "name": "pseudoIdentifier",
+                            "description": "Pseudo element custom ident.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
                             "name": "matches",
                             "description": "Matches of CSS rules applicable to the pseudo style.",
                             "type": "array",
@@ -2620,6 +3302,21 @@
                             "type": "array",
                             "items": {
                                 "$ref": "RuleMatch"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "InheritedPseudoElementMatches",
+                    "description": "Inherited pseudo element matches from pseudos of an ancestor node.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "pseudoElements",
+                            "description": "Matches of pseudo styles from the pseudos of an ancestor node.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "PseudoElementMatches"
                             }
                         }
                     ]
@@ -2659,6 +3356,36 @@
                             "description": "Value range in the underlying resource (if available).",
                             "optional": true,
                             "$ref": "SourceRange"
+                        },
+                        {
+                            "name": "specificity",
+                            "description": "Specificity of the selector.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "Specificity"
+                        }
+                    ]
+                },
+                {
+                    "id": "Specificity",
+                    "description": "Specificity:\nhttps://drafts.csswg.org/selectors/#specificity-rules",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "a",
+                            "description": "The a component, which represents the number of ID selectors.",
+                            "type": "integer"
+                        },
+                        {
+                            "name": "b",
+                            "description": "The b component, which represents the number of class selectors, attributes selectors, and\npseudo-classes.",
+                            "type": "integer"
+                        },
+                        {
+                            "name": "c",
+                            "description": "The c component, which represents the number of type selectors and pseudo-elements.",
+                            "type": "integer"
                         }
                     ]
                 },
@@ -2699,7 +3426,7 @@
                         },
                         {
                             "name": "sourceURL",
-                            "description": "Stylesheet resource URL. Empty if this is a constructed stylesheet created using\nnew CSSStyleSheet() (but non-empty if this is a constructed sylesheet imported\nas a CSS module script).",
+                            "description": "Stylesheet resource URL. Empty if this is a constructed stylesheet created using\nnew CSSStyleSheet() (but non-empty if this is a constructed stylesheet imported\nas a CSS module script).",
                             "type": "string"
                         },
                         {
@@ -2742,7 +3469,7 @@
                         },
                         {
                             "name": "isMutable",
-                            "description": "Whether this stylesheet is mutable. Inline stylesheets become mutable\nafter they have been modified via CSSOM API.\n<link> element's stylesheets become mutable only if DevTools modifies them.\nConstructed stylesheets (new CSSStyleSheet()) are mutable immediately after creation.",
+                            "description": "Whether this stylesheet is mutable. Inline stylesheets become mutable\nafter they have been modified via CSSOM API.\n`<link>` element's stylesheets become mutable only if DevTools modifies them.\nConstructed stylesheets (new CSSStyleSheet()) are mutable immediately after creation.",
                             "type": "boolean"
                         },
                         {
@@ -2774,6 +3501,13 @@
                             "name": "endColumn",
                             "description": "Column offset of the end of the stylesheet within the resource (zero based).",
                             "type": "number"
+                        },
+                        {
+                            "name": "loadingFailed",
+                            "description": "If the style sheet was loaded from a network resource, this indicates when the resource failed to load",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ]
                 },
@@ -2792,6 +3526,16 @@
                             "name": "selectorList",
                             "description": "Rule selector data.",
                             "$ref": "SelectorList"
+                        },
+                        {
+                            "name": "nestingSelectors",
+                            "description": "Array of selectors from ancestor style rules, sorted by distance from the current rule.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
                         },
                         {
                             "name": "origin",
@@ -2821,7 +3565,61 @@
                             "items": {
                                 "$ref": "CSSContainerQuery"
                             }
+                        },
+                        {
+                            "name": "supports",
+                            "description": "@supports CSS at-rule array.\nThe array enumerates @supports at-rules starting with the innermost one, going outwards.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "CSSSupports"
+                            }
+                        },
+                        {
+                            "name": "layers",
+                            "description": "Cascade layer array. Contains the layer hierarchy that this rule belongs to starting\nwith the innermost layer and going outwards.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "CSSLayer"
+                            }
+                        },
+                        {
+                            "name": "scopes",
+                            "description": "@scope CSS at-rule array.\nThe array enumerates @scope at-rules starting with the innermost one, going outwards.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "CSSScope"
+                            }
+                        },
+                        {
+                            "name": "ruleTypes",
+                            "description": "The array keeps the types of ancestor CSSRules from the innermost going outwards.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "CSSRuleType"
+                            }
                         }
+                    ]
+                },
+                {
+                    "id": "CSSRuleType",
+                    "description": "Enum indicating the type of a CSS rule, used to represent the order of a style rule's ancestors.\nThis list only contains rule types that are collected during the ancestor rule collection.",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "MediaRule",
+                        "SupportsRule",
+                        "ContainerRule",
+                        "LayerRule",
+                        "ScopeRule",
+                        "StyleRule"
                     ]
                 },
                 {
@@ -3007,6 +3805,16 @@
                             "description": "The entire property range in the enclosing style declaration (if available).",
                             "optional": true,
                             "$ref": "SourceRange"
+                        },
+                        {
+                            "name": "longhandProperties",
+                            "description": "Parsed longhand components of this property if it is a shorthand.\nThis field will be empty if the given property is not a shorthand.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "CSSProperty"
+                            }
                         }
                     ]
                 },
@@ -3142,6 +3950,125 @@
                             "description": "Optional name for the container.",
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "physicalAxes",
+                            "description": "Optional physical axes queried for the container.",
+                            "optional": true,
+                            "$ref": "DOM.PhysicalAxes"
+                        },
+                        {
+                            "name": "logicalAxes",
+                            "description": "Optional logical axes queried for the container.",
+                            "optional": true,
+                            "$ref": "DOM.LogicalAxes"
+                        }
+                    ]
+                },
+                {
+                    "id": "CSSSupports",
+                    "description": "CSS Supports at-rule descriptor.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "text",
+                            "description": "Supports rule text.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "active",
+                            "description": "Whether the supports condition is satisfied.",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "range",
+                            "description": "The associated rule header range in the enclosing stylesheet (if\navailable).",
+                            "optional": true,
+                            "$ref": "SourceRange"
+                        },
+                        {
+                            "name": "styleSheetId",
+                            "description": "Identifier of the stylesheet containing this object (if exists).",
+                            "optional": true,
+                            "$ref": "StyleSheetId"
+                        }
+                    ]
+                },
+                {
+                    "id": "CSSScope",
+                    "description": "CSS Scope at-rule descriptor.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "text",
+                            "description": "Scope rule text.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "range",
+                            "description": "The associated rule header range in the enclosing stylesheet (if\navailable).",
+                            "optional": true,
+                            "$ref": "SourceRange"
+                        },
+                        {
+                            "name": "styleSheetId",
+                            "description": "Identifier of the stylesheet containing this object (if exists).",
+                            "optional": true,
+                            "$ref": "StyleSheetId"
+                        }
+                    ]
+                },
+                {
+                    "id": "CSSLayer",
+                    "description": "CSS Layer at-rule descriptor.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "text",
+                            "description": "Layer name.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "range",
+                            "description": "The associated rule header range in the enclosing stylesheet (if\navailable).",
+                            "optional": true,
+                            "$ref": "SourceRange"
+                        },
+                        {
+                            "name": "styleSheetId",
+                            "description": "Identifier of the stylesheet containing this object (if exists).",
+                            "optional": true,
+                            "$ref": "StyleSheetId"
+                        }
+                    ]
+                },
+                {
+                    "id": "CSSLayerData",
+                    "description": "CSS Layer data.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "description": "Layer name.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "subLayers",
+                            "description": "Direct sub-layers",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "CSSLayerData"
+                            }
+                        },
+                        {
+                            "name": "order",
+                            "description": "Layer order. The order determines the order of the layer in the cascade order.\nA higher number has higher priority in the cascade order.",
+                            "type": "number"
                         }
                     ]
                 },
@@ -3153,6 +4080,11 @@
                         {
                             "name": "familyName",
                             "description": "Font's family name reported by platform.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "postScriptName",
+                            "description": "Font's PostScript name reported by platform.",
                             "type": "string"
                         },
                         {
@@ -3230,6 +4162,11 @@
                             "type": "string"
                         },
                         {
+                            "name": "fontDisplay",
+                            "description": "The font-display.",
+                            "type": "string"
+                        },
+                        {
                             "name": "unicodeRange",
                             "description": "The unicode-range.",
                             "type": "string"
@@ -3256,6 +4193,81 @@
                     ]
                 },
                 {
+                    "id": "CSSTryRule",
+                    "description": "CSS try rule representation.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "styleSheetId",
+                            "description": "The css style sheet identifier (absent for user agent stylesheet and user-specified\nstylesheet rules) this rule came from.",
+                            "optional": true,
+                            "$ref": "StyleSheetId"
+                        },
+                        {
+                            "name": "origin",
+                            "description": "Parent stylesheet's origin.",
+                            "$ref": "StyleSheetOrigin"
+                        },
+                        {
+                            "name": "style",
+                            "description": "Associated style declaration.",
+                            "$ref": "CSSStyle"
+                        }
+                    ]
+                },
+                {
+                    "id": "CSSPositionFallbackRule",
+                    "description": "CSS position-fallback rule representation.",
+                    "deprecated": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "$ref": "Value"
+                        },
+                        {
+                            "name": "tryRules",
+                            "description": "List of keyframes.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "CSSTryRule"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "CSSPositionTryRule",
+                    "description": "CSS @position-try rule representation.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "description": "The prelude dashed-ident name",
+                            "$ref": "Value"
+                        },
+                        {
+                            "name": "styleSheetId",
+                            "description": "The css style sheet identifier (absent for user agent stylesheet and user-specified\nstylesheet rules) this rule came from.",
+                            "optional": true,
+                            "$ref": "StyleSheetId"
+                        },
+                        {
+                            "name": "origin",
+                            "description": "Parent stylesheet's origin.",
+                            "$ref": "StyleSheetOrigin"
+                        },
+                        {
+                            "name": "style",
+                            "description": "Associated style declaration.",
+                            "$ref": "CSSStyle"
+                        },
+                        {
+                            "name": "active",
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
                     "id": "CSSKeyframesRule",
                     "description": "CSS keyframes rule representation.",
                     "type": "object",
@@ -3272,6 +4284,86 @@
                             "items": {
                                 "$ref": "CSSKeyframeRule"
                             }
+                        }
+                    ]
+                },
+                {
+                    "id": "CSSPropertyRegistration",
+                    "description": "Representation of a custom property registration through CSS.registerProperty",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "propertyName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "initialValue",
+                            "optional": true,
+                            "$ref": "Value"
+                        },
+                        {
+                            "name": "inherits",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "syntax",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "CSSFontPaletteValuesRule",
+                    "description": "CSS font-palette-values rule representation.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "styleSheetId",
+                            "description": "The css style sheet identifier (absent for user agent stylesheet and user-specified\nstylesheet rules) this rule came from.",
+                            "optional": true,
+                            "$ref": "StyleSheetId"
+                        },
+                        {
+                            "name": "origin",
+                            "description": "Parent stylesheet's origin.",
+                            "$ref": "StyleSheetOrigin"
+                        },
+                        {
+                            "name": "fontPaletteName",
+                            "description": "Associated font palette name.",
+                            "$ref": "Value"
+                        },
+                        {
+                            "name": "style",
+                            "description": "Associated style declaration.",
+                            "$ref": "CSSStyle"
+                        }
+                    ]
+                },
+                {
+                    "id": "CSSPropertyRule",
+                    "description": "CSS property at-rule representation.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "styleSheetId",
+                            "description": "The css style sheet identifier (absent for user agent stylesheet and user-specified\nstylesheet rules) this rule came from.",
+                            "optional": true,
+                            "$ref": "StyleSheetId"
+                        },
+                        {
+                            "name": "origin",
+                            "description": "Parent stylesheet's origin.",
+                            "$ref": "StyleSheetOrigin"
+                        },
+                        {
+                            "name": "propertyName",
+                            "description": "Associated property name.",
+                            "$ref": "Value"
+                        },
+                        {
+                            "name": "style",
+                            "description": "Associated style declaration.",
+                            "$ref": "CSSStyle"
                         }
                     ]
                 },
@@ -3345,6 +4437,13 @@
                             "name": "location",
                             "description": "Text position of a new rule in the target style sheet.",
                             "$ref": "SourceRange"
+                        },
+                        {
+                            "name": "nodeForPropertySyntaxValidation",
+                            "description": "NodeId for the DOM node in whose context custom property declarations for registered properties should be\nvalidated. If omitted, declarations in the new rule text can only be validated statically, which may produce\nincorrect results if the declaration contains a var() for example.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "DOM.NodeId"
                         }
                     ],
                     "returns": [
@@ -3547,6 +4646,15 @@
                             }
                         },
                         {
+                            "name": "inheritedPseudoElements",
+                            "description": "A chain of inherited pseudo element styles (from the immediate node parent up to the DOM tree root).",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "InheritedPseudoElementMatches"
+                            }
+                        },
+                        {
                             "name": "cssKeyframesRules",
                             "description": "A list of CSS keyframed animations matching this node.",
                             "optional": true,
@@ -3554,6 +4662,62 @@
                             "items": {
                                 "$ref": "CSSKeyframesRule"
                             }
+                        },
+                        {
+                            "name": "cssPositionFallbackRules",
+                            "description": "A list of CSS position fallbacks matching this node.",
+                            "deprecated": true,
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "CSSPositionFallbackRule"
+                            }
+                        },
+                        {
+                            "name": "cssPositionTryRules",
+                            "description": "A list of CSS @position-try rules matching this node, based on the position-try-fallbacks property.",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "CSSPositionTryRule"
+                            }
+                        },
+                        {
+                            "name": "activePositionFallbackIndex",
+                            "description": "Index of the active fallback in the applied position-try-fallback property,\nwill not be set if there is no active position-try fallback.",
+                            "optional": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "cssPropertyRules",
+                            "description": "A list of CSS at-property rules matching this node.",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "CSSPropertyRule"
+                            }
+                        },
+                        {
+                            "name": "cssPropertyRegistrations",
+                            "description": "A list of CSS property registrations matching this node.",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "CSSPropertyRegistration"
+                            }
+                        },
+                        {
+                            "name": "cssFontPaletteValuesRule",
+                            "description": "A font-palette-values rule matching this node.",
+                            "optional": true,
+                            "$ref": "CSSFontPaletteValuesRule"
+                        },
+                        {
+                            "name": "parentLayoutNodeId",
+                            "description": "Id of the first parent element that does not have display: contents.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "DOM.NodeId"
                         }
                     ]
                 },
@@ -3608,6 +4772,47 @@
                     ]
                 },
                 {
+                    "name": "getLayersForNode",
+                    "description": "Returns all layers parsed by the rendering engine for the tree scope of a node.\nGiven a DOM element identified by nodeId, getLayersForNode returns the root\nlayer for the nearest ancestor document or shadow root. The layer root contains\nthe full layer tree for the tree scope and their ordering.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "nodeId",
+                            "$ref": "DOM.NodeId"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "rootLayer",
+                            "$ref": "CSSLayerData"
+                        }
+                    ]
+                },
+                {
+                    "name": "getLocationForSelector",
+                    "description": "Given a CSS selector text and a style sheet ID, getLocationForSelector\nreturns an array of locations of the CSS selector in the style sheet.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "styleSheetId",
+                            "$ref": "StyleSheetId"
+                        },
+                        {
+                            "name": "selectorText",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "ranges",
+                            "type": "array",
+                            "items": {
+                                "$ref": "SourceRange"
+                            }
+                        }
+                    ]
+                },
+                {
                     "name": "trackComputedStyleUpdates",
                     "description": "Starts tracking the given computed styles for updates. The specified array of properties\nreplaces the one previously specified. Pass empty array to disable tracking.\nUse takeComputedStyleUpdates to retrieve the list of nodes that had properties modified.\nThe changes to computed style properties are only tracked for nodes pushed to the front-end\nby the DOM agent. If no changes to the tracked properties occur after the node has been pushed\nto the front-end, no updates will be issued for the node.",
                     "experimental": true,
@@ -3628,7 +4833,7 @@
                     "returns": [
                         {
                             "name": "nodeIds",
-                            "description": "The list of node Ids that have their tracked computed styles updated",
+                            "description": "The list of node Ids that have their tracked computed styles updated.",
                             "type": "array",
                             "items": {
                                 "$ref": "DOM.NodeId"
@@ -3652,6 +4857,31 @@
                         {
                             "name": "value",
                             "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "setPropertyRulePropertyName",
+                    "description": "Modifies the property rule property name.",
+                    "parameters": [
+                        {
+                            "name": "styleSheetId",
+                            "$ref": "StyleSheetId"
+                        },
+                        {
+                            "name": "range",
+                            "$ref": "SourceRange"
+                        },
+                        {
+                            "name": "propertyName",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "propertyName",
+                            "description": "The resulting key text after modification.",
+                            "$ref": "Value"
                         }
                     ]
                 },
@@ -3732,6 +4962,58 @@
                     ]
                 },
                 {
+                    "name": "setSupportsText",
+                    "description": "Modifies the expression of a supports at-rule.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "styleSheetId",
+                            "$ref": "StyleSheetId"
+                        },
+                        {
+                            "name": "range",
+                            "$ref": "SourceRange"
+                        },
+                        {
+                            "name": "text",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "supports",
+                            "description": "The resulting CSS Supports rule after modification.",
+                            "$ref": "CSSSupports"
+                        }
+                    ]
+                },
+                {
+                    "name": "setScopeText",
+                    "description": "Modifies the expression of a scope at-rule.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "styleSheetId",
+                            "$ref": "StyleSheetId"
+                        },
+                        {
+                            "name": "range",
+                            "$ref": "SourceRange"
+                        },
+                        {
+                            "name": "text",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "scope",
+                            "description": "The resulting CSS Scope rule after modification.",
+                            "$ref": "CSSScope"
+                        }
+                    ]
+                },
+                {
                     "name": "setRuleSelector",
                     "description": "Modifies the rule selector.",
                     "parameters": [
@@ -3788,6 +5070,13 @@
                             "items": {
                                 "$ref": "StyleDeclarationEdit"
                             }
+                        },
+                        {
+                            "name": "nodeForPropertySyntaxValidation",
+                            "description": "NodeId for the DOM node in whose context custom property declarations for registered properties should be\nvalidated. If omitted, declarations in the new rule text can only be validated statically, which may produce\nincorrect results if the declaration contains a var() for example.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "DOM.NodeId"
                         }
                     ],
                     "returns": [
@@ -3807,7 +5096,7 @@
                 },
                 {
                     "name": "stopRuleUsageTracking",
-                    "description": "Stop tracking rule usage and return the list of rules that were used since last call to\n`takeCoverageDelta` (or since start of coverage instrumentation)",
+                    "description": "Stop tracking rule usage and return the list of rules that were used since last call to\n`takeCoverageDelta` (or since start of coverage instrumentation).",
                     "returns": [
                         {
                             "name": "ruleUsage",
@@ -3820,7 +5109,7 @@
                 },
                 {
                     "name": "takeCoverageDelta",
-                    "description": "Obtain list of rules that became used since last call to this method (or since start of coverage\ninstrumentation)",
+                    "description": "Obtain list of rules that became used since last call to this method (or since start of coverage\ninstrumentation).",
                     "returns": [
                         {
                             "name": "coverage",
@@ -3852,7 +5141,7 @@
             "events": [
                 {
                     "name": "fontsUpdated",
-                    "description": "Fires whenever a web font is updated.  A non-empty font parameter indicates a successfully loaded\nweb font",
+                    "description": "Fires whenever a web font is updated.  A non-empty font parameter indicates a successfully loaded\nweb font.",
                     "parameters": [
                         {
                             "name": "font",
@@ -3903,6 +5192,9 @@
         {
             "domain": "CacheStorage",
             "experimental": true,
+            "dependencies": [
+                "Storage"
+            ],
             "types": [
                 {
                     "id": "CacheId",
@@ -3991,6 +5283,17 @@
                             "type": "string"
                         },
                         {
+                            "name": "storageKey",
+                            "description": "Storage key of the cache.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "storageBucket",
+                            "description": "Storage bucket of the cache.",
+                            "optional": true,
+                            "$ref": "Storage.StorageBucket"
+                        },
+                        {
                             "name": "cacheName",
                             "description": "The name of the cache.",
                             "type": "string"
@@ -4058,8 +5361,21 @@
                     "parameters": [
                         {
                             "name": "securityOrigin",
-                            "description": "Security origin.",
+                            "description": "At least and at most one of securityOrigin, storageKey, storageBucket must be specified.\nSecurity origin.",
+                            "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "storageBucket",
+                            "description": "Storage bucket. If not specified, it uses the default bucket.",
+                            "optional": true,
+                            "$ref": "Storage.StorageBucket"
                         }
                     ],
                     "returns": [
@@ -4203,6 +5519,16 @@
                     ]
                 },
                 {
+                    "name": "startDesktopMirroring",
+                    "description": "Starts mirroring the desktop to the sink.",
+                    "parameters": [
+                        {
+                            "name": "sinkName",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
                     "name": "startTabMirroring",
                     "description": "Starts mirroring the tab to the sink.",
                     "parameters": [
@@ -4251,7 +5577,7 @@
         },
         {
             "domain": "DOM",
-            "description": "This domain exposes DOM read/write operations. Each DOM Node is represented with its mirror object\nthat has an `id`. This `id` can be used to get additional information on the Node, resolve it into\nthe JavaScript object wrapper, etc. It is important that client receives DOM events only for the\nnodes that are known to the client. Backend keeps track of the nodes that were sent to the client\nand never sends the same node twice. It is client's responsibility to collect information about\nthe nodes that were sent to the client.<p>Note that `iframe` owner elements will return\ncorresponding document elements as their child nodes.</p>",
+            "description": "This domain exposes DOM read/write operations. Each DOM Node is represented with its mirror object\nthat has an `id`. This `id` can be used to get additional information on the Node, resolve it into\nthe JavaScript object wrapper, etc. It is important that client receives DOM events only for the\nnodes that are known to the client. Backend keeps track of the nodes that were sent to the client\nand never sends the same node twice. It is client's responsibility to collect information about\nthe nodes that were sent to the client. Note that `iframe` owner elements will return\ncorresponding document elements as their child nodes.",
             "dependencies": [
                 "Runtime"
             ],
@@ -4299,11 +5625,14 @@
                         "marker",
                         "backdrop",
                         "selection",
+                        "search-text",
                         "target-text",
                         "spelling-error",
                         "grammar-error",
                         "highlight",
                         "first-line-inherited",
+                        "scroll-marker",
+                        "scroll-marker-group",
                         "scrollbar",
                         "scrollbar-thumb",
                         "scrollbar-button",
@@ -4311,7 +5640,12 @@
                         "scrollbar-track-piece",
                         "scrollbar-corner",
                         "resizer",
-                        "input-list-button"
+                        "input-list-button",
+                        "view-transition",
+                        "view-transition-group",
+                        "view-transition-image-pair",
+                        "view-transition-old",
+                        "view-transition-new"
                     ]
                 },
                 {
@@ -4332,6 +5666,35 @@
                         "QuirksMode",
                         "LimitedQuirksMode",
                         "NoQuirksMode"
+                    ]
+                },
+                {
+                    "id": "PhysicalAxes",
+                    "description": "ContainerSelector physical axes",
+                    "type": "string",
+                    "enum": [
+                        "Horizontal",
+                        "Vertical",
+                        "Both"
+                    ]
+                },
+                {
+                    "id": "LogicalAxes",
+                    "description": "ContainerSelector logical axes",
+                    "type": "string",
+                    "enum": [
+                        "Inline",
+                        "Block",
+                        "Both"
+                    ]
+                },
+                {
+                    "id": "ScrollOrientation",
+                    "description": "Physical scroll orientation",
+                    "type": "string",
+                    "enum": [
+                        "horizontal",
+                        "vertical"
                     ]
                 },
                 {
@@ -4454,6 +5817,12 @@
                             "$ref": "PseudoType"
                         },
                         {
+                            "name": "pseudoIdentifier",
+                            "description": "Pseudo element identifier for this node. Only present if there is a\nvalid pseudoType.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
                             "name": "shadowRootType",
                             "description": "Shadow root type.",
                             "optional": true,
@@ -4521,6 +5890,11 @@
                             "name": "compatibilityMode",
                             "optional": true,
                             "$ref": "CompatibilityMode"
+                        },
+                        {
+                            "name": "assignedSlot",
+                            "optional": true,
+                            "$ref": "BackendNode"
                         }
                     ]
                 },
@@ -4774,7 +6148,6 @@
                 {
                     "name": "scrollIntoViewIfNeeded",
                     "description": "Scrolls the specified rect of the given node into view if not already visible.\nNote: exactly one between nodeId, backendNodeId and objectId should be passed\nto identify the node.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "nodeId",
@@ -4820,7 +6193,20 @@
                 },
                 {
                     "name": "enable",
-                    "description": "Enables DOM agent for the given page."
+                    "description": "Enables DOM agent for the given page.",
+                    "parameters": [
+                        {
+                            "name": "includeWhitespace",
+                            "description": "Whether to include whitespaces in the children array of returned Nodes.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "string",
+                            "enum": [
+                                "none",
+                                "all"
+                            ]
+                        }
+                    ]
                 },
                 {
                     "name": "focus",
@@ -4852,7 +6238,7 @@
                     "parameters": [
                         {
                             "name": "nodeId",
-                            "description": "Id of the node to retrieve attibutes for.",
+                            "description": "Id of the node to retrieve attributes for.",
                             "$ref": "NodeId"
                         }
                     ],
@@ -4935,7 +6321,7 @@
                 },
                 {
                     "name": "getDocument",
-                    "description": "Returns the root DOM node (and optionally the subtree) to the caller.",
+                    "description": "Returns the root DOM node (and optionally the subtree) to the caller.\nImplicitly enables the DOM domain events for the current target.",
                     "parameters": [
                         {
                             "name": "depth",
@@ -5324,6 +6710,48 @@
                     ]
                 },
                 {
+                    "name": "getTopLayerElements",
+                    "description": "Returns NodeIds of current top layer elements.\nTop layer is rendered closest to the user within a viewport, therefore its elements always\nappear on top of all other content.",
+                    "experimental": true,
+                    "returns": [
+                        {
+                            "name": "nodeIds",
+                            "description": "NodeIds of top layer elements",
+                            "type": "array",
+                            "items": {
+                                "$ref": "NodeId"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "getElementByRelation",
+                    "description": "Returns the NodeId of the matched element according to certain relations.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "nodeId",
+                            "description": "Id of the node from which to query the relation.",
+                            "$ref": "NodeId"
+                        },
+                        {
+                            "name": "relation",
+                            "description": "Type of relation to get.",
+                            "type": "string",
+                            "enum": [
+                                "PopoverTarget"
+                            ]
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "nodeId",
+                            "description": "NodeId of the element matching the queried relation.",
+                            "$ref": "NodeId"
+                        }
+                    ]
+                },
+                {
                     "name": "redo",
                     "description": "Re-does the last undone action.",
                     "experimental": true
@@ -5656,7 +7084,7 @@
                 },
                 {
                     "name": "getContainerForNode",
-                    "description": "Returns the container of the given node based on container query conditions.\nIf containerName is given, it will find the nearest container with a matching name;\notherwise it will find the nearest container regardless of its container name.",
+                    "description": "Returns the query container of the given node based on container query\nconditions: containerName, physical, and logical axes. If no axes are\nprovided, the style container is returned, which is the direct parent or the\nclosest element with a matching container-name.",
                     "experimental": true,
                     "parameters": [
                         {
@@ -5667,6 +7095,16 @@
                             "name": "containerName",
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "physicalAxes",
+                            "optional": true,
+                            "$ref": "PhysicalAxes"
+                        },
+                        {
+                            "name": "logicalAxes",
+                            "optional": true,
+                            "$ref": "LogicalAxes"
                         }
                     ],
                     "returns": [
@@ -5697,6 +7135,31 @@
                             "items": {
                                 "$ref": "NodeId"
                             }
+                        }
+                    ]
+                },
+                {
+                    "name": "getAnchorElement",
+                    "description": "Returns the target anchor element of the given anchor query according to\nhttps://www.w3.org/TR/css-anchor-position-1/#target.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "nodeId",
+                            "description": "Id of the positioned element from which to find the anchor.",
+                            "$ref": "NodeId"
+                        },
+                        {
+                            "name": "anchorSpecifier",
+                            "description": "An optional anchor specifier, as defined in\nhttps://www.w3.org/TR/css-anchor-position-1/#anchor-specifier.\nIf not provided, it will return the implicit anchor element for\nthe given positioned element.",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "nodeId",
+                            "description": "The anchor element of the given anchor query.",
+                            "$ref": "NodeId"
                         }
                     ]
                 }
@@ -5782,7 +7245,7 @@
                         },
                         {
                             "name": "previousNodeId",
-                            "description": "If of the previous siblint.",
+                            "description": "Id of the previous sibling.",
                             "$ref": "NodeId"
                         },
                         {
@@ -5865,6 +7328,11 @@
                     ]
                 },
                 {
+                    "name": "topLayerElementsUpdated",
+                    "description": "Called when top layer elements are changed.",
+                    "experimental": true
+                },
+                {
                     "name": "pseudoElementRemoved",
                     "description": "Called when a pseudo element is removed from an element.",
                     "experimental": true,
@@ -5941,7 +7409,6 @@
             "description": "DOM debugging allows setting breakpoints on particular DOM operations and events. JavaScript\nexecution will stop on these operations as if there was a regular breakpoint set.",
             "dependencies": [
                 "DOM",
-                "Debugger",
                 "Runtime"
             ],
             "types": [
@@ -6098,6 +7565,8 @@
                     "name": "removeInstrumentationBreakpoint",
                     "description": "Removes breakpoint on particular native event.",
                     "experimental": true,
+                    "deprecated": true,
+                    "redirect": "EventBreakpoints",
                     "parameters": [
                         {
                             "name": "eventName",
@@ -6170,6 +7639,8 @@
                     "name": "setInstrumentationBreakpoint",
                     "description": "Sets breakpoint on particular native event.",
                     "experimental": true,
+                    "deprecated": true,
+                    "redirect": "EventBreakpoints",
                     "parameters": [
                         {
                             "name": "eventName",
@@ -6193,7 +7664,7 @@
         },
         {
             "domain": "EventBreakpoints",
-            "description": "EventBreakpoints permits setting breakpoints on particular operations and\nevents in targets that run JavaScript but do not have a DOM.\nJavaScript execution will stop on these operations as if there was a regular\nbreakpoint set.",
+            "description": "EventBreakpoints permits setting JavaScript breakpoints on operations and events\noccurring in native code invoked from JavaScript. Once breakpoint is hit, it is\nreported through Debugger domain, similarly to regular breakpoints being hit.",
             "experimental": true,
             "commands": [
                 {
@@ -6217,6 +7688,10 @@
                             "type": "string"
                         }
                     ]
+                },
+                {
+                    "name": "disable",
+                    "description": "Removes all breakpoints"
                 }
             ]
         },
@@ -6779,6 +8254,12 @@
                             "$ref": "RareStringData"
                         },
                         {
+                            "name": "pseudoIdentifier",
+                            "description": "Pseudo element identifier for this node. Only present if there is a\nvalid pseudoType.",
+                            "optional": true,
+                            "$ref": "RareStringData"
+                        },
+                        {
                             "name": "isClickable",
                             "description": "Whether this DOM node responds to mouse clicks. This includes nodes that have had click\nevent listeners attached via JavaScript as well as anchor tags that naturally navigate when\nclicked.",
                             "optional": true,
@@ -7072,6 +8553,10 @@
             "experimental": true,
             "types": [
                 {
+                    "id": "SerializedStorageKey",
+                    "type": "string"
+                },
+                {
                     "id": "StorageId",
                     "description": "DOM Storage identifier.",
                     "type": "object",
@@ -7079,7 +8564,14 @@
                         {
                             "name": "securityOrigin",
                             "description": "Security origin for the storage.",
+                            "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "storageKey",
+                            "description": "Represents a key by which DOM Storage keys its CachedStorageAreas",
+                            "optional": true,
+                            "$ref": "SerializedStorageKey"
                         },
                         {
                             "name": "isLocalStorage",
@@ -7446,6 +8938,21 @@
                     ]
                 },
                 {
+                    "id": "DevicePosture",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "type",
+                            "description": "Current posture of the device",
+                            "type": "string",
+                            "enum": [
+                                "continuous",
+                                "folded"
+                            ]
+                        }
+                    ]
+                },
+                {
                     "id": "MediaFeature",
                     "type": "object",
                     "properties": [
@@ -7472,7 +8979,7 @@
                 },
                 {
                     "id": "UserAgentBrandVersion",
-                    "description": "Used to specify User Agent Cient Hints to emulate. See https://wicg.github.io/ua-client-hints",
+                    "description": "Used to specify User Agent Client Hints to emulate. See https://wicg.github.io/ua-client-hints",
                     "experimental": true,
                     "type": "object",
                     "properties": [
@@ -7488,12 +8995,13 @@
                 },
                 {
                     "id": "UserAgentMetadata",
-                    "description": "Used to specify User Agent Cient Hints to emulate. See https://wicg.github.io/ua-client-hints\nMissing optional values will be filled in by the target with what it would normally use.",
+                    "description": "Used to specify User Agent Client Hints to emulate. See https://wicg.github.io/ua-client-hints\nMissing optional values will be filled in by the target with what it would normally use.",
                     "experimental": true,
                     "type": "object",
                     "properties": [
                         {
                             "name": "brands",
+                            "description": "Brands appearing in Sec-CH-UA.",
                             "optional": true,
                             "type": "array",
                             "items": {
@@ -7502,6 +9010,7 @@
                         },
                         {
                             "name": "fullVersionList",
+                            "description": "Brands appearing in Sec-CH-UA-Full-Version-List.",
                             "optional": true,
                             "type": "array",
                             "items": {
@@ -7533,6 +9042,161 @@
                         {
                             "name": "mobile",
                             "type": "boolean"
+                        },
+                        {
+                            "name": "bitness",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "wow64",
+                            "optional": true,
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "id": "SensorType",
+                    "description": "Used to specify sensor types to emulate.\nSee https://w3c.github.io/sensors/#automation for more information.",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "absolute-orientation",
+                        "accelerometer",
+                        "ambient-light",
+                        "gravity",
+                        "gyroscope",
+                        "linear-acceleration",
+                        "magnetometer",
+                        "proximity",
+                        "relative-orientation"
+                    ]
+                },
+                {
+                    "id": "SensorMetadata",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "available",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "minimumFrequency",
+                            "optional": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "maximumFrequency",
+                            "optional": true,
+                            "type": "number"
+                        }
+                    ]
+                },
+                {
+                    "id": "SensorReadingSingle",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "value",
+                            "type": "number"
+                        }
+                    ]
+                },
+                {
+                    "id": "SensorReadingXYZ",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "x",
+                            "type": "number"
+                        },
+                        {
+                            "name": "y",
+                            "type": "number"
+                        },
+                        {
+                            "name": "z",
+                            "type": "number"
+                        }
+                    ]
+                },
+                {
+                    "id": "SensorReadingQuaternion",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "x",
+                            "type": "number"
+                        },
+                        {
+                            "name": "y",
+                            "type": "number"
+                        },
+                        {
+                            "name": "z",
+                            "type": "number"
+                        },
+                        {
+                            "name": "w",
+                            "type": "number"
+                        }
+                    ]
+                },
+                {
+                    "id": "SensorReading",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "single",
+                            "optional": true,
+                            "$ref": "SensorReadingSingle"
+                        },
+                        {
+                            "name": "xyz",
+                            "optional": true,
+                            "$ref": "SensorReadingXYZ"
+                        },
+                        {
+                            "name": "quaternion",
+                            "optional": true,
+                            "$ref": "SensorReadingQuaternion"
+                        }
+                    ]
+                },
+                {
+                    "id": "PressureSource",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "cpu"
+                    ]
+                },
+                {
+                    "id": "PressureState",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "nominal",
+                        "fair",
+                        "serious",
+                        "critical"
+                    ]
+                },
+                {
+                    "id": "PressureMetadata",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "available",
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ]
                 },
@@ -7543,7 +9207,6 @@
                     "type": "string",
                     "enum": [
                         "avif",
-                        "jxl",
                         "webp"
                     ]
                 }
@@ -7552,6 +9215,7 @@
                 {
                     "name": "canEmulate",
                     "description": "Tells whether emulation is supported.",
+                    "deprecated": true,
                     "returns": [
                         {
                             "name": "result",
@@ -7601,7 +9265,6 @@
                 {
                     "name": "setCPUThrottlingRate",
                     "description": "Enables CPU throttling to emulate slow CPUs.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "rate",
@@ -7707,8 +9370,32 @@
                             "experimental": true,
                             "optional": true,
                             "$ref": "DisplayFeature"
+                        },
+                        {
+                            "name": "devicePosture",
+                            "description": "If set, the posture of a foldable device. If not set the posture is set\nto continuous.\nDeprecated, use Emulation.setDevicePostureOverride.",
+                            "experimental": true,
+                            "deprecated": true,
+                            "optional": true,
+                            "$ref": "DevicePosture"
                         }
                     ]
+                },
+                {
+                    "name": "setDevicePostureOverride",
+                    "description": "Start reporting the given posture value to the Device Posture API.\nThis override can also be set in setDeviceMetricsOverride().",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "posture",
+                            "$ref": "DevicePosture"
+                        }
+                    ]
+                },
+                {
+                    "name": "clearDevicePostureOverride",
+                    "description": "Clears a device posture override set with either setDeviceMetricsOverride()\nor setDevicePostureOverride() and starts using posture information from the\nplatform again.\nDoes nothing if no override is set.",
+                    "experimental": true
                 },
                 {
                     "name": "setScrollbarsHidden",
@@ -7777,16 +9464,16 @@
                 {
                     "name": "setEmulatedVisionDeficiency",
                     "description": "Emulates the given vision deficiency.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "type",
-                            "description": "Vision deficiency to emulate.",
+                            "description": "Vision deficiency to emulate. Order: best-effort emulations come first, followed by any\nphysiologically accurate emulations for medically recognized color vision deficiencies.",
                             "type": "string",
                             "enum": [
                                 "none",
-                                "achromatopsia",
                                 "blurredVision",
+                                "reducedContrast",
+                                "achromatopsia",
                                 "deuteranopia",
                                 "protanopia",
                                 "tritanopia"
@@ -7819,9 +9506,94 @@
                     ]
                 },
                 {
+                    "name": "getOverriddenSensorInformation",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "type",
+                            "$ref": "SensorType"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "requestedSamplingFrequency",
+                            "type": "number"
+                        }
+                    ]
+                },
+                {
+                    "name": "setSensorOverrideEnabled",
+                    "description": "Overrides a platform sensor of a given type. If |enabled| is true, calls to\nSensor.start() will use a virtual sensor as backend rather than fetching\ndata from a real hardware sensor. Otherwise, existing virtual\nsensor-backend Sensor objects will fire an error event and new calls to\nSensor.start() will attempt to use a real sensor instead.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "enabled",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "type",
+                            "$ref": "SensorType"
+                        },
+                        {
+                            "name": "metadata",
+                            "optional": true,
+                            "$ref": "SensorMetadata"
+                        }
+                    ]
+                },
+                {
+                    "name": "setSensorOverrideReadings",
+                    "description": "Updates the sensor readings reported by a sensor type previously overridden\nby setSensorOverrideEnabled.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "type",
+                            "$ref": "SensorType"
+                        },
+                        {
+                            "name": "reading",
+                            "$ref": "SensorReading"
+                        }
+                    ]
+                },
+                {
+                    "name": "setPressureSourceOverrideEnabled",
+                    "description": "Overrides a pressure source of a given type, as used by the Compute\nPressure API, so that updates to PressureObserver.observe() are provided\nvia setPressureStateOverride instead of being retrieved from\nplatform-provided telemetry data.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "enabled",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "source",
+                            "$ref": "PressureSource"
+                        },
+                        {
+                            "name": "metadata",
+                            "optional": true,
+                            "$ref": "PressureMetadata"
+                        }
+                    ]
+                },
+                {
+                    "name": "setPressureStateOverride",
+                    "description": "Provides a given pressure state that will be processed and eventually be\ndelivered to PressureObserver users. |source| must have been previously\noverridden by setPressureSourceOverrideEnabled.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "source",
+                            "$ref": "PressureSource"
+                        },
+                        {
+                            "name": "state",
+                            "$ref": "PressureState"
+                        }
+                    ]
+                },
+                {
                     "name": "setIdleOverride",
                     "description": "Overrides the Idle state.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "isUserActive",
@@ -7837,8 +9609,7 @@
                 },
                 {
                     "name": "clearIdleOverride",
-                    "description": "Clears Idle state overrides.",
-                    "experimental": true
+                    "description": "Clears Idle state overrides."
                 },
                 {
                     "name": "setNavigatorOverrides",
@@ -7915,12 +9686,6 @@
                             "type": "integer"
                         },
                         {
-                            "name": "waitForNavigation",
-                            "description": "If set the virtual time policy change should be deferred until any frame starts navigating.\nNote any previous deferred policy change is superseded.",
-                            "optional": true,
-                            "type": "boolean"
-                        },
-                        {
                             "name": "initialVirtualTime",
                             "description": "If set, base::Time::Now will be overridden to initially return this value.",
                             "optional": true,
@@ -7951,11 +9716,10 @@
                 {
                     "name": "setTimezoneOverride",
                     "description": "Overrides default host system timezone with the specified one.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "timezoneId",
-                            "description": "The timezone identifier. If empty, disables the override and\nrestores default host system timezone.",
+                            "description": "The timezone identifier. List of supported timezones:\nhttps://source.chromium.org/chromium/chromium/deps/icu.git/+/faee8bc70570192d82d2978a71e2a615788597d1:source/data/misc/metaZones.txt\nIf empty, disables the override and restores default host system timezone.",
                             "type": "string"
                         }
                     ]
@@ -7993,8 +9757,19 @@
                     ]
                 },
                 {
+                    "name": "setHardwareConcurrencyOverride",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "hardwareConcurrency",
+                            "description": "Hardware concurrency to report",
+                            "type": "integer"
+                        }
+                    ]
+                },
+                {
                     "name": "setUserAgentOverride",
-                    "description": "Allows overriding user agent with the given string.",
+                    "description": "Allows overriding user agent with the given string.\n`userAgentMetadata` must be set for Client Hint headers to be sent.",
                     "parameters": [
                         {
                             "name": "userAgent",
@@ -8003,7 +9778,7 @@
                         },
                         {
                             "name": "acceptLanguage",
-                            "description": "Browser langugage to emulate.",
+                            "description": "Browser language to emulate.",
                             "optional": true,
                             "type": "string"
                         },
@@ -8019,6 +9794,18 @@
                             "experimental": true,
                             "optional": true,
                             "$ref": "UserAgentMetadata"
+                        }
+                    ]
+                },
+                {
+                    "name": "setAutomationOverride",
+                    "description": "Allows overriding the automation flag.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "enabled",
+                            "description": "Whether the override should be enabled.",
+                            "type": "boolean"
                         }
                     ]
                 }
@@ -8052,14 +9839,21 @@
                             "type": "string",
                             "enum": [
                                 "jpeg",
-                                "png"
+                                "png",
+                                "webp"
                             ]
                         },
                         {
                             "name": "quality",
-                            "description": "Compression quality from range [0..100] (jpeg only).",
+                            "description": "Compression quality from range [0..100] (jpeg and webp only).",
                             "optional": true,
                             "type": "integer"
+                        },
+                        {
+                            "name": "optimizeForSpeed",
+                            "description": "Optimize image encoding for speed, not for resulting size (defaults to false)",
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ]
                 }
@@ -8067,7 +9861,7 @@
             "commands": [
                 {
                     "name": "beginFrame",
-                    "description": "Sends a BeginFrame to the target and returns when the frame was completed. Optionally captures a\nscreenshot from the resulting frame. Requires that the target was created with enabled\nBeginFrameControl. Designed for use with --run-all-compositor-stages-before-draw, see also\nhttps://goo.gl/3zHXhB for more background.",
+                    "description": "Sends a BeginFrame to the target and returns when the frame was completed. Optionally captures a\nscreenshot from the resulting frame. Requires that the target was created with enabled\nBeginFrameControl. Designed for use with --run-all-compositor-stages-before-draw, see also\nhttps://goo.gle/chrome-headless-rendering for more background.",
                     "parameters": [
                         {
                             "name": "frameTimeTicks",
@@ -8110,25 +9904,13 @@
                 },
                 {
                     "name": "disable",
-                    "description": "Disables headless events for the target."
+                    "description": "Disables headless events for the target.",
+                    "deprecated": true
                 },
                 {
                     "name": "enable",
-                    "description": "Enables headless events for the target."
-                }
-            ],
-            "events": [
-                {
-                    "name": "needsBeginFramesChanged",
-                    "description": "Issued when the target starts or stops needing BeginFrames.\nDeprecated. Issue beginFrame unconditionally instead and use result from\nbeginFrame to detect whether the frames were suppressed.",
-                    "deprecated": true,
-                    "parameters": [
-                        {
-                            "name": "needsBeginFrames",
-                            "description": "True if BeginFrames are needed, false otherwise.",
-                            "type": "boolean"
-                        }
-                    ]
+                    "description": "Enables headless events for the target.",
+                    "deprecated": true
                 }
             ]
         },
@@ -8138,7 +9920,7 @@
             "types": [
                 {
                     "id": "StreamHandle",
-                    "description": "This is either obtained from another method or specified as `blob:&lt;uuid&gt;` where\n`&lt;uuid&gt` is an UUID of a Blob.",
+                    "description": "This is either obtained from another method or specified as `blob:<uuid>` where\n`<uuid>` is an UUID of a Blob.",
                     "type": "string"
                 }
             ],
@@ -8165,7 +9947,7 @@
                         },
                         {
                             "name": "offset",
-                            "description": "Seek to the specified offset before reading (if not specificed, proceed with offset\nfollowing the last read). Some types of streams may only support sequential reads.",
+                            "description": "Seek to the specified offset before reading (if not specified, proceed with offset\nfollowing the last read). Some types of streams may only support sequential reads.",
                             "optional": true,
                             "type": "integer"
                         },
@@ -8216,10 +9998,113 @@
             ]
         },
         {
+            "domain": "FileSystem",
+            "experimental": true,
+            "dependencies": [
+                "Network",
+                "Storage"
+            ],
+            "types": [
+                {
+                    "id": "File",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "type": "string"
+                        },
+                        {
+                            "name": "lastModified",
+                            "description": "Timestamp",
+                            "$ref": "Network.TimeSinceEpoch"
+                        },
+                        {
+                            "name": "size",
+                            "description": "Size in bytes",
+                            "type": "number"
+                        },
+                        {
+                            "name": "type",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "Directory",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "type": "string"
+                        },
+                        {
+                            "name": "nestedDirectories",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "name": "nestedFiles",
+                            "description": "Files that are directly nested under this directory.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "File"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "BucketFileSystemLocator",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key",
+                            "$ref": "Storage.SerializedStorageKey"
+                        },
+                        {
+                            "name": "bucketName",
+                            "description": "Bucket name. Not passing a `bucketName` will retrieve the default Bucket. (https://developer.mozilla.org/en-US/docs/Web/API/Storage_API#storage_buckets)",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "pathComponents",
+                            "description": "Path to the directory using each path component as an array item.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "commands": [
+                {
+                    "name": "getDirectory",
+                    "parameters": [
+                        {
+                            "name": "bucketFileSystemLocator",
+                            "$ref": "BucketFileSystemLocator"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "directory",
+                            "description": "Returns the directory object at the path.",
+                            "$ref": "Directory"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "domain": "IndexedDB",
             "experimental": true,
             "dependencies": [
-                "Runtime"
+                "Runtime",
+                "Storage"
             ],
             "types": [
                 {
@@ -8440,8 +10325,21 @@
                     "parameters": [
                         {
                             "name": "securityOrigin",
-                            "description": "Security origin.",
+                            "description": "At least and at most one of securityOrigin, storageKey, or storageBucket must be specified.\nSecurity origin.",
+                            "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "storageBucket",
+                            "description": "Storage bucket. If not specified, it uses the default bucket.",
+                            "optional": true,
+                            "$ref": "Storage.StorageBucket"
                         },
                         {
                             "name": "databaseName",
@@ -8461,8 +10359,21 @@
                     "parameters": [
                         {
                             "name": "securityOrigin",
-                            "description": "Security origin.",
+                            "description": "At least and at most one of securityOrigin, storageKey, or storageBucket must be specified.\nSecurity origin.",
+                            "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "storageBucket",
+                            "description": "Storage bucket. If not specified, it uses the default bucket.",
+                            "optional": true,
+                            "$ref": "Storage.StorageBucket"
                         },
                         {
                             "name": "databaseName",
@@ -8477,7 +10388,21 @@
                     "parameters": [
                         {
                             "name": "securityOrigin",
+                            "description": "At least and at most one of securityOrigin, storageKey, or storageBucket must be specified.\nSecurity origin.",
+                            "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "storageBucket",
+                            "description": "Storage bucket. If not specified, it uses the default bucket.",
+                            "optional": true,
+                            "$ref": "Storage.StorageBucket"
                         },
                         {
                             "name": "databaseName",
@@ -8508,8 +10433,21 @@
                     "parameters": [
                         {
                             "name": "securityOrigin",
-                            "description": "Security origin.",
+                            "description": "At least and at most one of securityOrigin, storageKey, or storageBucket must be specified.\nSecurity origin.",
+                            "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "storageBucket",
+                            "description": "Storage bucket. If not specified, it uses the default bucket.",
+                            "optional": true,
+                            "$ref": "Storage.StorageBucket"
                         },
                         {
                             "name": "databaseName",
@@ -8561,12 +10499,25 @@
                 },
                 {
                     "name": "getMetadata",
-                    "description": "Gets metadata of an object store",
+                    "description": "Gets metadata of an object store.",
                     "parameters": [
                         {
                             "name": "securityOrigin",
-                            "description": "Security origin.",
+                            "description": "At least and at most one of securityOrigin, storageKey, or storageBucket must be specified.\nSecurity origin.",
+                            "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "storageBucket",
+                            "description": "Storage bucket. If not specified, it uses the default bucket.",
+                            "optional": true,
+                            "$ref": "Storage.StorageBucket"
                         },
                         {
                             "name": "databaseName",
@@ -8598,8 +10549,21 @@
                     "parameters": [
                         {
                             "name": "securityOrigin",
-                            "description": "Security origin.",
+                            "description": "At least and at most one of securityOrigin, storageKey, or storageBucket must be specified.\nSecurity origin.",
+                            "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "storageBucket",
+                            "description": "Storage bucket. If not specified, it uses the default bucket.",
+                            "optional": true,
+                            "$ref": "Storage.StorageBucket"
                         },
                         {
                             "name": "databaseName",
@@ -8621,8 +10585,21 @@
                     "parameters": [
                         {
                             "name": "securityOrigin",
-                            "description": "Security origin.",
+                            "description": "At least and at most one of securityOrigin, storageKey, or storageBucket must be specified.\nSecurity origin.",
+                            "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "storageBucket",
+                            "description": "Storage bucket. If not specified, it uses the default bucket.",
+                            "optional": true,
+                            "$ref": "Storage.StorageBucket"
                         }
                     ],
                     "returns": [
@@ -8689,16 +10666,14 @@
                         {
                             "name": "tiltX",
                             "description": "The plane angle between the Y-Z plane and the plane containing both the stylus axis and the Y axis, in degrees of the range [-90,90], a positive tiltX is to the right (default: 0)",
-                            "experimental": true,
                             "optional": true,
-                            "type": "integer"
+                            "type": "number"
                         },
                         {
                             "name": "tiltY",
                             "description": "The plane angle between the X-Z plane and the plane containing both the stylus axis and the X axis, in degrees of the range [-90,90], a positive tiltY is towards the user (default: 0).",
-                            "experimental": true,
                             "optional": true,
-                            "type": "integer"
+                            "type": "number"
                         },
                         {
                             "name": "twist",
@@ -8934,7 +10909,7 @@
                         },
                         {
                             "name": "commands",
-                            "description": "Editing commands to send with the key event (e.g., 'selectAll') (default: []).\nThese are related to but not equal the command names used in `document.execCommand` and NSStandardKeyBindingResponding.\nSee https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/editing/commands/editor_command_names.h for valid command names.",
+                            "description": "Editing commands to send with the key event (e.g., 'selectAll') (default: []).\nThese are related to but not equal the command names used in `document.execCommand` and NSStandardKeyBindingResponding.\nSee https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/editing/commands/editor_command_names.h for valid command names.",
                             "experimental": true,
                             "optional": true,
                             "type": "array",
@@ -8958,7 +10933,7 @@
                 },
                 {
                     "name": "imeSetComposition",
-                    "description": "This method sets the current candidate text for ime.\nUse imeCommitComposition to commit the final text.\nUse imeSetComposition with empty string as text to cancel composition.",
+                    "description": "This method sets the current candidate text for IME.\nUse imeCommitComposition to commit the final text.\nUse imeSetComposition with empty string as text to cancel composition.",
                     "experimental": true,
                     "parameters": [
                         {
@@ -9062,16 +11037,14 @@
                         {
                             "name": "tiltX",
                             "description": "The plane angle between the Y-Z plane and the plane containing both the stylus axis and the Y axis, in degrees of the range [-90,90], a positive tiltX is to the right (default: 0).",
-                            "experimental": true,
                             "optional": true,
-                            "type": "integer"
+                            "type": "number"
                         },
                         {
                             "name": "tiltY",
                             "description": "The plane angle between the X-Z plane and the plane containing both the stylus axis and the X axis, in degrees of the range [-90,90], a positive tiltY is towards the user (default: 0).",
-                            "experimental": true,
                             "optional": true,
-                            "type": "integer"
+                            "type": "number"
                         },
                         {
                             "name": "twist",
@@ -9140,6 +11113,10 @@
                             "$ref": "TimeSinceEpoch"
                         }
                     ]
+                },
+                {
+                    "name": "cancelDragging",
+                    "description": "Cancels any active dragging in the page."
                 },
                 {
                     "name": "emulateTouchFromMouseEvent",
@@ -9638,7 +11615,6 @@
                         {
                             "name": "compositingReasons",
                             "description": "A list of strings specifying reasons for the given layer to become composited.",
-                            "deprecated": true,
                             "type": "array",
                             "items": {
                                 "type": "string"
@@ -9829,7 +11805,7 @@
                     "parameters": [
                         {
                             "name": "layers",
-                            "description": "Layer tree, absent if not in the comspositing mode.",
+                            "description": "Layer tree, absent if not in the compositing mode.",
                             "optional": true,
                             "type": "array",
                             "items": {
@@ -10227,6 +12203,7 @@
                         "TextTrack",
                         "XHR",
                         "Fetch",
+                        "Prefetch",
                         "EventSource",
                         "WebSocket",
                         "Manifest",
@@ -10411,6 +12388,20 @@
                             "type": "number"
                         },
                         {
+                            "name": "workerRouterEvaluationStart",
+                            "description": "Started ServiceWorker static routing source evaluation.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "workerCacheLookupStart",
+                            "description": "Started cache lookup when the source was evaluated to `cache`.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "number"
+                        },
+                        {
                             "name": "sendStart",
                             "description": "Started sending request.",
                             "type": "number"
@@ -10429,6 +12420,12 @@
                         {
                             "name": "pushEnd",
                             "description": "Time the server finished pushing request.",
+                            "experimental": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "receiveHeadersStart",
+                            "description": "Started receiving response headers.",
                             "experimental": true,
                             "type": "number"
                         },
@@ -10491,7 +12488,8 @@
                         },
                         {
                             "name": "postData",
-                            "description": "HTTP POST request data.",
+                            "description": "HTTP POST request data.\nUse postDataEntries instead.",
+                            "deprecated": true,
                             "optional": true,
                             "type": "string"
                         },
@@ -10503,7 +12501,7 @@
                         },
                         {
                             "name": "postDataEntries",
-                            "description": "Request body elements. This will be converted from base64 to binary",
+                            "description": "Request body elements (post data broken into individual entries).",
                             "experimental": true,
                             "optional": true,
                             "type": "array",
@@ -10552,7 +12550,7 @@
                         },
                         {
                             "name": "isSameSite",
-                            "description": "True if this resource request is considered to be the 'same site' as the\nrequest correspondinfg to the main frame.",
+                            "description": "True if this resource request is considered to be the 'same site' as the\nrequest corresponding to the main frame.",
                             "experimental": true,
                             "optional": true,
                             "type": "boolean"
@@ -10683,6 +12681,17 @@
                             "name": "certificateTransparencyCompliance",
                             "description": "Whether the request complied with Certificate Transparency policy",
                             "$ref": "CertificateTransparencyCompliance"
+                        },
+                        {
+                            "name": "serverSignatureAlgorithm",
+                            "description": "The signature algorithm used by the server in the TLS server signature,\nrepresented as a TLS SignatureScheme code point. Omitted if not\napplicable or not known.",
+                            "optional": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "encryptedClientHello",
+                            "description": "Whether the connection used Encrypted ClientHello",
+                            "type": "boolean"
                         }
                     ]
                 },
@@ -10712,6 +12721,8 @@
                         "coop-sandboxed-iframe-cannot-navigate-to-coop-page",
                         "corp-not-same-origin",
                         "corp-not-same-origin-after-defaulted-to-same-origin-by-coep",
+                        "corp-not-same-origin-after-defaulted-to-same-origin-by-dip",
+                        "corp-not-same-origin-after-defaulted-to-same-origin-by-coep-and-dip",
                         "corp-not-same-site"
                     ]
                 },
@@ -10739,6 +12750,8 @@
                         "PreflightInvalidAllowCredentials",
                         "PreflightMissingAllowExternal",
                         "PreflightInvalidAllowExternal",
+                        "PreflightMissingAllowPrivateNetwork",
+                        "PreflightInvalidAllowPrivateNetwork",
                         "InvalidAllowMethodsPreflightResponse",
                         "InvalidAllowHeadersPreflightResponse",
                         "MethodDisallowedByPreflightResponse",
@@ -10747,7 +12760,11 @@
                         "InsecurePrivateNetwork",
                         "InvalidPrivateNetworkAccess",
                         "UnexpectedPrivateNetworkAccess",
-                        "NoCorsRedirectModeNotFollow"
+                        "NoCorsRedirectModeNotFollow",
+                        "PreflightMissingPrivateNetworkAccessId",
+                        "PreflightMissingPrivateNetworkAccessName",
+                        "PrivateNetworkAccessPermissionUnavailable",
+                        "PrivateNetworkAccessPermissionDenied"
                     ]
                 },
                 {
@@ -10782,12 +12799,12 @@
                     "type": "object",
                     "properties": [
                         {
-                            "name": "type",
+                            "name": "operation",
                             "$ref": "TrustTokenOperationType"
                         },
                         {
                             "name": "refreshPolicy",
-                            "description": "Only set for \"token-redemption\" type and determine whether\nto request a fresh SRR or use a still valid cached SRR.",
+                            "description": "Only set for \"token-redemption\" operation and determine whether\nto request a fresh SRR or use a still valid cached SRR.",
                             "type": "string",
                             "enum": [
                                 "UseCached",
@@ -10813,6 +12830,58 @@
                         "Issuance",
                         "Redemption",
                         "Signing"
+                    ]
+                },
+                {
+                    "id": "AlternateProtocolUsage",
+                    "description": "The reason why Chrome uses a specific transport protocol for HTTP semantics.",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "alternativeJobWonWithoutRace",
+                        "alternativeJobWonRace",
+                        "mainJobWonRace",
+                        "mappingMissing",
+                        "broken",
+                        "dnsAlpnH3JobWonWithoutRace",
+                        "dnsAlpnH3JobWonRace",
+                        "unspecifiedReason"
+                    ]
+                },
+                {
+                    "id": "ServiceWorkerRouterSource",
+                    "description": "Source of service worker router.",
+                    "type": "string",
+                    "enum": [
+                        "network",
+                        "cache",
+                        "fetch-event",
+                        "race-network-and-fetch-handler"
+                    ]
+                },
+                {
+                    "id": "ServiceWorkerRouterInfo",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "ruleIdMatched",
+                            "description": "ID of the rule matched. If there is a matched rule, this field will\nbe set, otherwiser no value will be set.",
+                            "optional": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "matchedSourceType",
+                            "description": "The router source of the matched rule. If there is a matched rule, this\nfield will be set, otherwise no value will be set.",
+                            "optional": true,
+                            "$ref": "ServiceWorkerRouterSource"
+                        },
+                        {
+                            "name": "actualSourceType",
+                            "description": "The actual router source used.",
+                            "optional": true,
+                            "$ref": "ServiceWorkerRouterSource"
+                        }
                     ]
                 },
                 {
@@ -10850,6 +12919,11 @@
                         {
                             "name": "mimeType",
                             "description": "Resource mimeType as determined by the browser.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "charset",
+                            "description": "Resource charset as determined by the browser (if applicable).",
                             "type": "string"
                         },
                         {
@@ -10906,6 +12980,19 @@
                             "type": "boolean"
                         },
                         {
+                            "name": "fromEarlyHints",
+                            "description": "Specifies that the request was served from the prefetch cache.",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "serviceWorkerRouterInfo",
+                            "description": "Information about how ServiceWorker Static Router API was used. If this\nfield is set with `matchedSourceType` field, a matching rule is found.\nIf this field is set without `matchedSource`, no matching rule is found.\nOtherwise, the API is not used.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "ServiceWorkerRouterInfo"
+                        },
+                        {
                             "name": "encodedDataLength",
                             "description": "Total number of bytes received for this request so far.",
                             "type": "number"
@@ -10939,6 +13026,13 @@
                             "description": "Protocol used to fetch this request.",
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "alternateProtocolUsage",
+                            "description": "The reason why Chrome uses a specific transport protocol for HTTP semantics.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "AlternateProtocolUsage"
                         },
                         {
                             "name": "securityState",
@@ -11106,6 +13200,24 @@
                     ]
                 },
                 {
+                    "id": "CookiePartitionKey",
+                    "description": "cookiePartitionKey object\nThe representation of the components of the key that are created by the cookiePartitionKey class contained in net/cookies/cookie_partition_key.h.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "topLevelSite",
+                            "description": "The site of the top-level URL the browser was visiting at the start\nof the request to the endpoint that set the cookie.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "hasCrossSiteAncestor",
+                            "description": "Indicates if the cookie has any ancestors that are cross-site to the topLevelSite.",
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
                     "id": "Cookie",
                     "description": "Cookie object",
                     "type": "object",
@@ -11171,6 +13283,7 @@
                             "name": "sameParty",
                             "description": "True if cookie is SameParty.",
                             "experimental": true,
+                            "deprecated": true,
                             "type": "boolean"
                         },
                         {
@@ -11187,10 +13300,10 @@
                         },
                         {
                             "name": "partitionKey",
-                            "description": "Cookie partition key. The site of the top-level URL the browser was visiting at the start\nof the request to the endpoint that set the cookie.",
+                            "description": "Cookie partition key.",
                             "experimental": true,
                             "optional": true,
-                            "type": "string"
+                            "$ref": "CookiePartitionKey"
                         },
                         {
                             "name": "partitionKeyOpaque",
@@ -11213,6 +13326,8 @@
                         "SameSiteUnspecifiedTreatedAsLax",
                         "SameSiteNoneInsecure",
                         "UserPreferences",
+                        "ThirdPartyPhaseout",
+                        "ThirdPartyBlockedInFirstPartySet",
                         "SyntaxError",
                         "SchemeNotSupported",
                         "OverwriteSecure",
@@ -11224,7 +13339,9 @@
                         "SchemefulSameSiteUnspecifiedTreatedAsLax",
                         "SamePartyFromCrossPartyContext",
                         "SamePartyConflictsWithOtherAttributes",
-                        "NameValuePairExceedsMaxSize"
+                        "NameValuePairExceedsMaxSize",
+                        "DisallowedCharacter",
+                        "NoCookieContent"
                     ]
                 },
                 {
@@ -11241,12 +13358,32 @@
                         "SameSiteUnspecifiedTreatedAsLax",
                         "SameSiteNoneInsecure",
                         "UserPreferences",
+                        "ThirdPartyPhaseout",
+                        "ThirdPartyBlockedInFirstPartySet",
                         "UnknownError",
                         "SchemefulSameSiteStrict",
                         "SchemefulSameSiteLax",
                         "SchemefulSameSiteUnspecifiedTreatedAsLax",
                         "SamePartyFromCrossPartyContext",
                         "NameValuePairExceedsMaxSize"
+                    ]
+                },
+                {
+                    "id": "CookieExemptionReason",
+                    "description": "Types of reasons why a cookie should have been blocked by 3PCD but is exempted for the request.",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "None",
+                        "UserSetting",
+                        "TPCDMetadata",
+                        "TPCDDeprecationTrial",
+                        "TPCDHeuristics",
+                        "EnterprisePolicy",
+                        "StorageAccess",
+                        "TopLevelStorageAccess",
+                        "CorsOptIn",
+                        "Scheme"
                     ]
                 },
                 {
@@ -11277,23 +13414,52 @@
                     ]
                 },
                 {
-                    "id": "BlockedCookieWithReason",
-                    "description": "A cookie with was not sent with a request with the corresponding reason.",
+                    "id": "ExemptedSetCookieWithReason",
+                    "description": "A cookie should have been blocked by 3PCD but is exempted and stored from a response with the\ncorresponding reason. A cookie could only have at most one exemption reason.",
                     "experimental": true,
                     "type": "object",
                     "properties": [
                         {
+                            "name": "exemptionReason",
+                            "description": "The reason the cookie was exempted.",
+                            "$ref": "CookieExemptionReason"
+                        },
+                        {
+                            "name": "cookieLine",
+                            "description": "The string representing this individual cookie as it would appear in the header.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "cookie",
+                            "description": "The cookie object representing the cookie.",
+                            "$ref": "Cookie"
+                        }
+                    ]
+                },
+                {
+                    "id": "AssociatedCookie",
+                    "description": "A cookie associated with the request which may or may not be sent with it.\nIncludes the cookies itself and reasons for blocking or exemption.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "cookie",
+                            "description": "The cookie object representing the cookie which was not sent.",
+                            "$ref": "Cookie"
+                        },
+                        {
                             "name": "blockedReasons",
-                            "description": "The reason(s) the cookie was blocked.",
+                            "description": "The reason(s) the cookie was blocked. If empty means the cookie is included.",
                             "type": "array",
                             "items": {
                                 "$ref": "CookieBlockedReason"
                             }
                         },
                         {
-                            "name": "cookie",
-                            "description": "The cookie object representing the cookie which was not sent.",
-                            "$ref": "Cookie"
+                            "name": "exemptionReason",
+                            "description": "The reason the cookie should have been blocked by 3PCD but is exempted. A cookie could\nonly have at most one exemption reason.",
+                            "optional": true,
+                            "$ref": "CookieExemptionReason"
                         }
                     ]
                 },
@@ -11384,10 +13550,10 @@
                         },
                         {
                             "name": "partitionKey",
-                            "description": "Cookie partition key. The site of the top-level URL the browser was visiting at the start\nof the request to the endpoint that set the cookie.\nIf not set, the cookie will be set as not partitioned.",
+                            "description": "Cookie partition key. If not set, the cookie will be set as not partitioned.",
                             "experimental": true,
                             "optional": true,
-                            "type": "string"
+                            "$ref": "CookiePartitionKey"
                         }
                     ]
                 },
@@ -11580,7 +13746,7 @@
                         },
                         {
                             "name": "headerIntegrity",
-                            "description": "Signed exchange header integrity hash in the form of \"sha256-<base64-hash-value>\".",
+                            "description": "Signed exchange header integrity hash in the form of `sha256-<base64-hash-value>`.",
                             "type": "string"
                         }
                     ]
@@ -11649,7 +13815,7 @@
                         },
                         {
                             "name": "errors",
-                            "description": "Errors occurred while handling the signed exchagne.",
+                            "description": "Errors occurred while handling the signed exchange.",
                             "optional": true,
                             "type": "array",
                             "items": {
@@ -11666,7 +13832,8 @@
                     "enum": [
                         "deflate",
                         "gzip",
-                        "br"
+                        "br",
+                        "zstd"
                     ]
                 },
                 {
@@ -11730,8 +13897,11 @@
                     "enum": [
                         "SameOrigin",
                         "SameOriginAllowPopups",
+                        "RestrictProperties",
                         "UnsafeNone",
-                        "SameOriginPlusCoep"
+                        "SameOriginPlusCoep",
+                        "RestrictPropertiesPlusCoep",
+                        "NoopenerAllowPopups"
                     ]
                 },
                 {
@@ -11795,6 +13965,34 @@
                     ]
                 },
                 {
+                    "id": "ContentSecurityPolicySource",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "HTTP",
+                        "Meta"
+                    ]
+                },
+                {
+                    "id": "ContentSecurityPolicyStatus",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "effectiveDirectives",
+                            "type": "string"
+                        },
+                        {
+                            "name": "isEnforced",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "source",
+                            "$ref": "ContentSecurityPolicySource"
+                        }
+                    ]
+                },
+                {
                     "id": "SecurityIsolationStatus",
                     "experimental": true,
                     "type": "object",
@@ -11808,6 +14006,14 @@
                             "name": "coep",
                             "optional": true,
                             "$ref": "CrossOriginEmbedderPolicyStatus"
+                        },
+                        {
+                            "name": "csp",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "ContentSecurityPolicyStatus"
+                            }
                         }
                     ]
                 },
@@ -12073,7 +14279,7 @@
                 },
                 {
                     "name": "deleteCookies",
-                    "description": "Deletes browser cookies with matching name and url or domain/path pair.",
+                    "description": "Deletes browser cookies with matching name and url or domain/path/partitionKey pair.",
                     "parameters": [
                         {
                             "name": "name",
@@ -12097,6 +14303,13 @@
                             "description": "If specified, deletes only cookies with the exact path.",
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "partitionKey",
+                            "description": "If specified, deletes only cookies with the the given name and partitionKey where\nall partition key attributes match the cookie partition key attribute.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "CookiePartitionKey"
                         }
                     ]
                 },
@@ -12133,6 +14346,27 @@
                             "description": "Connection type if known.",
                             "optional": true,
                             "$ref": "ConnectionType"
+                        },
+                        {
+                            "name": "packetLoss",
+                            "description": "WebRTC packet loss (percent, 0-100). 0 disables packet loss emulation, 100 drops all the packets.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "packetQueueLength",
+                            "description": "WebRTC packet queue length (packet). 0 removes any queue length limitations.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "packetReordering",
+                            "description": "WebRTC packetReordering feature.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ]
                 },
@@ -12164,7 +14398,8 @@
                 },
                 {
                     "name": "getAllCookies",
-                    "description": "Returns all browser cookies. Depending on the backend support, will return detailed cookie\ninformation in the `cookies` field.",
+                    "description": "Returns all browser cookies. Depending on the backend support, will return detailed cookie\ninformation in the `cookies` field.\nDeprecated. Use Storage.getCookies instead.",
+                    "deprecated": true,
                     "returns": [
                         {
                             "name": "cookies",
@@ -12373,7 +14608,6 @@
                 {
                     "name": "setBypassServiceWorker",
                     "description": "Toggles ignoring of service worker for each request.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "bypass",
@@ -12479,10 +14713,10 @@
                         },
                         {
                             "name": "partitionKey",
-                            "description": "Cookie partition key. The site of the top-level URL the browser was visiting at the start\nof the request to the endpoint that set the cookie.\nIf not set, the cookie will be set as not partitioned.",
+                            "description": "Cookie partition key. If not set, the cookie will be set as not partitioned.",
                             "experimental": true,
                             "optional": true,
-                            "type": "string"
+                            "$ref": "CookiePartitionKey"
                         }
                     ],
                     "returns": [
@@ -12559,7 +14793,7 @@
                         },
                         {
                             "name": "acceptLanguage",
-                            "description": "Browser langugage to emulate.",
+                            "description": "Browser language to emulate.",
                             "optional": true,
                             "type": "string"
                         },
@@ -12575,6 +14809,25 @@
                             "experimental": true,
                             "optional": true,
                             "$ref": "Emulation.UserAgentMetadata"
+                        }
+                    ]
+                },
+                {
+                    "name": "streamResourceContent",
+                    "description": "Enables streaming of the response for the given requestId.\nIf enabled, the dataReceived event contains the data that was received during streaming.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "requestId",
+                            "description": "Identifier of the request to stream.",
+                            "$ref": "RequestId"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "bufferedData",
+                            "description": "Data that has been buffered until streaming is enabled. (Encoded as a base64 string when passed over JSON)",
+                            "type": "string"
                         }
                     ]
                 },
@@ -12663,6 +14916,13 @@
                             "name": "encodedDataLength",
                             "description": "Actual bytes received (might be less than dataLength for compressed encodings).",
                             "type": "integer"
+                        },
+                        {
+                            "name": "data",
+                            "description": "Data that was received. (Encoded as a base64 string when passed over JSON)",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "string"
                         }
                     ]
                 },
@@ -12718,7 +14978,7 @@
                         },
                         {
                             "name": "errorText",
-                            "description": "User friendly error message.",
+                            "description": "Error message. List of network errors: https://cs.chromium.org/chromium/src/net/base/net_error_list.h",
                             "type": "string"
                         },
                         {
@@ -12759,12 +15019,6 @@
                             "name": "encodedDataLength",
                             "description": "Total number of bytes received for this request.",
                             "type": "number"
-                        },
-                        {
-                            "name": "shouldReportCorbBlocking",
-                            "description": "Set when 1) response was blocked by Cross-Origin Read Blocking and also\n2) this needs to be reported to the DevTools console.",
-                            "optional": true,
-                            "type": "boolean"
                         }
                     ]
                 },
@@ -13225,10 +15479,10 @@
                         },
                         {
                             "name": "associatedCookies",
-                            "description": "A list of cookies potentially associated to the requested URL. This includes both cookies sent with\nthe request and the ones not sent; the latter are distinguished by having blockedReason field set.",
+                            "description": "A list of cookies potentially associated to the requested URL. This includes both cookies sent with\nthe request and the ones not sent; the latter are distinguished by having blockedReasons field set.",
                             "type": "array",
                             "items": {
-                                "$ref": "BlockedCookieWithReason"
+                                "$ref": "AssociatedCookie"
                             }
                         },
                         {
@@ -13247,6 +15501,12 @@
                             "description": "The client security state set for the request.",
                             "optional": true,
                             "$ref": "ClientSecurityState"
+                        },
+                        {
+                            "name": "siteHasCookieInOtherPartition",
+                            "description": "Whether the site has partitioned cookies stored in a partition different than the current one.",
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ]
                 },
@@ -13288,6 +15548,45 @@
                             "description": "Raw response header text as it was received over the wire. The raw text may not always be\navailable, such as in the case of HTTP/2 or QUIC.",
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "cookiePartitionKey",
+                            "description": "The cookie partition key that will be used to store partitioned cookies set in this response.\nOnly sent when partitioned cookies are enabled.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "CookiePartitionKey"
+                        },
+                        {
+                            "name": "cookiePartitionKeyOpaque",
+                            "description": "True if partitioned cookies are enabled, but the partition key is not serializable to string.",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "exemptedCookies",
+                            "description": "A list of cookies which should have been blocked by 3PCD but are exempted and stored from\nthe response with the corresponding reason.",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "ExemptedSetCookieWithReason"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "responseReceivedEarlyHints",
+                    "description": "Fired when 103 Early Hints headers is received in addition to the common response.\nNot every responseReceived event will have an responseReceivedEarlyHints fired.\nOnly one responseReceivedEarlyHints may be fired for eached responseReceived event.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "requestId",
+                            "description": "Request identifier. Used to match this information to another responseReceived event.",
+                            "$ref": "RequestId"
+                        },
+                        {
+                            "name": "headers",
+                            "description": "Raw response headers as they were received over the wire.",
+                            "$ref": "Headers"
                         }
                     ]
                 },
@@ -13303,10 +15602,12 @@
                             "enum": [
                                 "Ok",
                                 "InvalidArgument",
+                                "MissingIssuerKeys",
                                 "FailedPrecondition",
                                 "ResourceExhausted",
                                 "AlreadyExists",
-                                "Unavailable",
+                                "ResourceLimited",
+                                "Unauthorized",
                                 "BadResponse",
                                 "InternalError",
                                 "UnknownError",
@@ -13340,6 +15641,11 @@
                             "type": "integer"
                         }
                     ]
+                },
+                {
+                    "name": "policyUpdated",
+                    "description": "Fired once security policy has been updated.",
+                    "experimental": true
                 },
                 {
                     "name": "subresourceWebBundleMetadataReceived",
@@ -13487,7 +15793,7 @@
                     "properties": [
                         {
                             "name": "parentOutlineColor",
-                            "description": "the color to outline the givent element in.",
+                            "description": "the color to outline the given element in.",
                             "$ref": "DOM.RGBA"
                         },
                         {
@@ -13884,6 +16190,7 @@
                     "enum": [
                         "rgb",
                         "hsl",
+                        "hwb",
                         "hex"
                     ]
                 },
@@ -13987,6 +16294,28 @@
                             "description": "The content box highlight outline color (default: transparent).",
                             "optional": true,
                             "$ref": "DOM.RGBA"
+                        }
+                    ]
+                },
+                {
+                    "id": "WindowControlsOverlayConfig",
+                    "description": "Configuration for Window Controls Overlay",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "showCSS",
+                            "description": "Whether the title bar CSS should be shown when emulating the Window Controls Overlay.",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "selectedPlatform",
+                            "description": "Selected platforms to show the overlay.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "themeColor",
+                            "description": "The theme color defined in app manifest.",
+                            "type": "string"
                         }
                     ]
                 },
@@ -14172,7 +16501,7 @@
                 },
                 {
                     "name": "highlightFrame",
-                    "description": "Highlights owner element of the frame with given id.\nDeprecated: Doesn't work reliablity and cannot be fixed due to process\nseparatation (the owner node might be in a different process). Determine\nthe owner node in the client and use highlightNode.",
+                    "description": "Highlights owner element of the frame with given id.\nDeprecated: Doesn't work reliably and cannot be fixed due to process\nseparation (the owner node might be in a different process). Determine\nthe owner node in the client and use highlightNode.",
                     "deprecated": true,
                     "parameters": [
                         {
@@ -14468,7 +16797,8 @@
                 },
                 {
                     "name": "setShowHitTestBorders",
-                    "description": "Requests that backend shows hit-test borders on layers",
+                    "description": "Deprecated, no longer has any effect.",
+                    "deprecated": true,
                     "parameters": [
                         {
                             "name": "show",
@@ -14521,6 +16851,18 @@
                             "items": {
                                 "$ref": "IsolatedElementHighlightConfig"
                             }
+                        }
+                    ]
+                },
+                {
+                    "name": "setShowWindowControlsOverlay",
+                    "description": "Show Window Controls Overlay for PWA",
+                    "parameters": [
+                        {
+                            "name": "windowControlsOverlayConfig",
+                            "description": "Window Controls Overlay data, null means hide Window Controls Overlay",
+                            "optional": true,
+                            "$ref": "WindowControlsOverlayConfig"
                         }
                     ]
                 }
@@ -14622,6 +16964,24 @@
                     ]
                 },
                 {
+                    "id": "AdScriptId",
+                    "description": "Identifies the bottom-most script which caused the frame to be labelled\nas an ad.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "scriptId",
+                            "description": "Script Id of the bottom-most script which caused the frame to be labelled\nas an ad.",
+                            "$ref": "Runtime.ScriptId"
+                        },
+                        {
+                            "name": "debuggerId",
+                            "description": "Id of adScriptId's debugger.",
+                            "$ref": "Runtime.UniqueDebuggerId"
+                        }
+                    ]
+                },
+                {
                     "id": "SecureContextType",
                     "description": "Indicates whether the frame is a secure context and why it is the case.",
                     "experimental": true,
@@ -14662,32 +17022,43 @@
                     "type": "string",
                     "enum": [
                         "accelerometer",
+                        "all-screens-capture",
                         "ambient-light-sensor",
                         "attribution-reporting",
                         "autoplay",
+                        "bluetooth",
+                        "browsing-topics",
                         "camera",
+                        "captured-surface-control",
                         "ch-dpr",
                         "ch-device-memory",
                         "ch-downlink",
                         "ch-ect",
                         "ch-prefers-color-scheme",
+                        "ch-prefers-reduced-motion",
+                        "ch-prefers-reduced-transparency",
                         "ch-rtt",
+                        "ch-save-data",
                         "ch-ua",
                         "ch-ua-arch",
                         "ch-ua-bitness",
                         "ch-ua-platform",
                         "ch-ua-model",
                         "ch-ua-mobile",
+                        "ch-ua-form-factors",
                         "ch-ua-full-version",
                         "ch-ua-full-version-list",
                         "ch-ua-platform-version",
-                        "ch-ua-reduced",
+                        "ch-ua-wow64",
                         "ch-viewport-height",
                         "ch-viewport-width",
                         "ch-width",
                         "clipboard-read",
                         "clipboard-write",
+                        "compute-pressure",
                         "cross-origin-isolated",
+                        "deferred-fetch",
+                        "digital-credentials-get",
                         "direct-sockets",
                         "display-capture",
                         "document-domain",
@@ -14701,28 +17072,42 @@
                         "geolocation",
                         "gyroscope",
                         "hid",
+                        "identity-credentials-get",
                         "idle-detection",
                         "interest-cohort",
                         "join-ad-interest-group",
                         "keyboard-map",
+                        "local-fonts",
                         "magnetometer",
+                        "media-playback-while-not-visible",
                         "microphone",
                         "midi",
                         "otp-credentials",
                         "payment",
                         "picture-in-picture",
+                        "private-aggregation",
+                        "private-state-token-issuance",
+                        "private-state-token-redemption",
+                        "publickey-credentials-create",
                         "publickey-credentials-get",
                         "run-ad-auction",
                         "screen-wake-lock",
                         "serial",
                         "shared-autofill",
-                        "storage-access-api",
+                        "shared-storage",
+                        "shared-storage-select-url",
+                        "smart-card",
+                        "speaker-selection",
+                        "storage-access",
+                        "sub-apps",
                         "sync-xhr",
-                        "trust-token-redemption",
+                        "unload",
                         "usb",
+                        "usb-unrestricted",
                         "vertical-scroll",
+                        "web-printing",
                         "web-share",
-                        "window-placement",
+                        "window-management",
                         "xr-spatial-tracking"
                     ]
                 },
@@ -14733,7 +17118,9 @@
                     "type": "string",
                     "enum": [
                         "Header",
-                        "IframeAttribute"
+                        "IframeAttribute",
+                        "InFencedFrameTree",
+                        "InIsolatedApp"
                     ]
                 },
                 {
@@ -15200,7 +17587,7 @@
                         },
                         {
                             "name": "critical",
-                            "description": "If criticial, this is a non-recoverable parse error.",
+                            "description": "If critical, this is a non-recoverable parse error.",
                             "type": "integer"
                         },
                         {
@@ -15378,10 +17765,28 @@
                             "type": "string"
                         },
                         {
-                            "name": "pictograph",
-                            "description": "The pictograph font-family.",
+                            "name": "math",
+                            "description": "The math font-family.",
                             "optional": true,
                             "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "ScriptFontFamilies",
+                    "description": "Font families collection for a script.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "script",
+                            "description": "Name of the script which these font families are defined for.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "fontFamilies",
+                            "description": "Generic font families collection for the script.",
+                            "$ref": "FontFamilies"
                         }
                     ]
                 },
@@ -15505,6 +17910,387 @@
                     ]
                 },
                 {
+                    "id": "FileFilter",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "accepts",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "FileHandler",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "action",
+                            "type": "string"
+                        },
+                        {
+                            "name": "name",
+                            "type": "string"
+                        },
+                        {
+                            "name": "icons",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "ImageResource"
+                            }
+                        },
+                        {
+                            "name": "accepts",
+                            "description": "Mimic a map, name is the key, accepts is the value.",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "FileFilter"
+                            }
+                        },
+                        {
+                            "name": "launchType",
+                            "description": "Won't repeat the enums, using string for easy comparison. Same as the\nother enums below.",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "ImageResource",
+                    "description": "The image definition used in both icon and screenshot.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "url",
+                            "description": "The src field in the definition, but changing to url in favor of\nconsistency.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "sizes",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "type",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "LaunchHandler",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "clientMode",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "ProtocolHandler",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "protocol",
+                            "type": "string"
+                        },
+                        {
+                            "name": "url",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "RelatedApplication",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "id",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "url",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "ScopeExtension",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "origin",
+                            "description": "Instead of using tuple, this field always returns the serialized string\nfor easy understanding and comparison.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "hasOriginWildcard",
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "id": "Screenshot",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "image",
+                            "$ref": "ImageResource"
+                        },
+                        {
+                            "name": "formFactor",
+                            "type": "string"
+                        },
+                        {
+                            "name": "label",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "ShareTarget",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "action",
+                            "type": "string"
+                        },
+                        {
+                            "name": "method",
+                            "type": "string"
+                        },
+                        {
+                            "name": "enctype",
+                            "type": "string"
+                        },
+                        {
+                            "name": "title",
+                            "description": "Embed the ShareTargetParams",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "text",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "url",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "files",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "FileFilter"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "Shortcut",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "name",
+                            "type": "string"
+                        },
+                        {
+                            "name": "url",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "WebAppManifest",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "backgroundColor",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "description",
+                            "description": "The extra description provided by the manifest.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "dir",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "display",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "displayOverrides",
+                            "description": "The overrided display mode controlled by the user.",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "name": "fileHandlers",
+                            "description": "The handlers to open files.",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "FileHandler"
+                            }
+                        },
+                        {
+                            "name": "icons",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "ImageResource"
+                            }
+                        },
+                        {
+                            "name": "id",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "lang",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "launchHandler",
+                            "description": "TODO(crbug.com/1231886): This field is non-standard and part of a Chrome\nexperiment. See:\nhttps://github.com/WICG/web-app-launch/blob/main/launch_handler.md",
+                            "optional": true,
+                            "$ref": "LaunchHandler"
+                        },
+                        {
+                            "name": "name",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "orientation",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "preferRelatedApplications",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "protocolHandlers",
+                            "description": "The handlers to open protocols.",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "ProtocolHandler"
+                            }
+                        },
+                        {
+                            "name": "relatedApplications",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "RelatedApplication"
+                            }
+                        },
+                        {
+                            "name": "scope",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "scopeExtensions",
+                            "description": "Non-standard, see\nhttps://github.com/WICG/manifest-incubations/blob/gh-pages/scope_extensions-explainer.md",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "ScopeExtension"
+                            }
+                        },
+                        {
+                            "name": "screenshots",
+                            "description": "The screenshots used by chromium.",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "Screenshot"
+                            }
+                        },
+                        {
+                            "name": "shareTarget",
+                            "optional": true,
+                            "$ref": "ShareTarget"
+                        },
+                        {
+                            "name": "shortName",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "shortcuts",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "Shortcut"
+                            }
+                        },
+                        {
+                            "name": "startUrl",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "themeColor",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "AutoResponseMode",
+                    "description": "Enum of possible auto-response for permission / prompt dialogs.",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "none",
+                        "autoAccept",
+                        "autoReject",
+                        "autoOptOut"
+                    ]
+                },
+                {
                     "id": "NavigationType",
                     "description": "The type of a frameNavigated event.",
                     "experimental": true,
@@ -15520,7 +18306,7 @@
                     "experimental": true,
                     "type": "string",
                     "enum": [
-                        "NotMainFrame",
+                        "NotPrimaryMainFrame",
                         "BackForwardCacheDisabled",
                         "RelatedActiveContentsExist",
                         "HTTPStatusNotOK",
@@ -15536,7 +18322,6 @@
                         "JavaScriptExecution",
                         "RendererProcessKilled",
                         "RendererProcessCrashed",
-                        "GrantedMediaStreamAccess",
                         "SchedulerTrackedFeatureUsed",
                         "ConflictingBrowsingInstance",
                         "CacheFlushed",
@@ -15563,7 +18348,6 @@
                         "ForegroundCacheLimit",
                         "BrowsingInstanceNotSwapped",
                         "BackForwardCacheDisabledForDelegate",
-                        "OptInUnloadHeaderNotPresent",
                         "UnloadHandlerExistsInMainFrame",
                         "UnloadHandlerExistsInSubFrame",
                         "ServiceWorkerUnregistration",
@@ -15573,6 +18357,17 @@
                         "NoResponseHead",
                         "Unknown",
                         "ActivationNavigationsDisallowedForBug1234857",
+                        "ErrorDocument",
+                        "FencedFramesEmbedder",
+                        "CookieDisabled",
+                        "HTTPAuthRequired",
+                        "CookieFlushed",
+                        "BroadcastChannelOnMessage",
+                        "WebViewSettingsChanged",
+                        "WebViewJavaScriptObjectChanged",
+                        "WebViewMessageListenerInjected",
+                        "WebViewSafeBrowsingAllowlistChanged",
+                        "WebViewDocumentStartJavascriptChanged",
                         "WebSocket",
                         "WebTransport",
                         "WebRTC",
@@ -15582,17 +18377,13 @@
                         "SubresourceHasCacheControlNoCache",
                         "ContainsPlugins",
                         "DocumentLoaded",
-                        "DedicatedWorkerOrWorklet",
                         "OutstandingNetworkRequestOthers",
-                        "OutstandingIndexedDBTransaction",
-                        "RequestedNotificationsPermission",
                         "RequestedMIDIPermission",
                         "RequestedAudioCapturePermission",
                         "RequestedVideoCapturePermission",
                         "RequestedBackForwardCacheBlockedSensors",
                         "RequestedBackgroundWorkPermission",
                         "BroadcastChannel",
-                        "IndexedDBConnection",
                         "WebXR",
                         "SharedWorker",
                         "WebLocks",
@@ -15606,7 +18397,6 @@
                         "Printing",
                         "WebDatabase",
                         "PictureInPicture",
-                        "Portal",
                         "SpeechRecognizer",
                         "IdleManager",
                         "PaymentManager",
@@ -15616,7 +18406,17 @@
                         "OutstandingNetworkRequestDirectSocket",
                         "InjectedJavascript",
                         "InjectedStyleSheet",
+                        "KeepaliveRequest",
+                        "IndexedDBEvent",
                         "Dummy",
+                        "JsNetworkRequestReceivedCacheControlNoStoreResource",
+                        "WebRTCSticky",
+                        "WebTransportSticky",
+                        "WebSocketSticky",
+                        "SmartCard",
+                        "LiveMediaStreamTrack",
+                        "UnloadHandler",
+                        "ParserAborted",
                         "ContentSecurityHandler",
                         "ContentWebAuthenticationAPI",
                         "ContentFileChooser",
@@ -15625,8 +18425,8 @@
                         "ContentMediaDevicesDispatcherHost",
                         "ContentWebBluetooth",
                         "ContentWebUSB",
-                        "ContentMediaSession",
                         "ContentMediaSessionService",
+                        "ContentScreenReader",
                         "EmbedderPopupBlockerTabHelper",
                         "EmbedderSafeBrowsingTriggeredPopupBlocker",
                         "EmbedderSafeBrowsingThreatDetails",
@@ -15641,7 +18441,8 @@
                         "EmbedderExtensions",
                         "EmbedderExtensionMessaging",
                         "EmbedderExtensionMessagingForOpenPort",
-                        "EmbedderExtensionSentMessageToCachedFrame"
+                        "EmbedderExtensionSentMessageToCachedFrame",
+                        "RequestedByWebViewClient"
                     ]
                 },
                 {
@@ -15653,6 +18454,35 @@
                         "SupportPending",
                         "PageSupportNeeded",
                         "Circumstantial"
+                    ]
+                },
+                {
+                    "id": "BackForwardCacheBlockingDetails",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "url",
+                            "description": "Url of the file where blockage happened. Optional because of tests.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "function",
+                            "description": "Function name where blockage happened. Optional because of anonymous functions and tests.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "lineNumber",
+                            "description": "Line number in the script (0-based).",
+                            "type": "integer"
+                        },
+                        {
+                            "name": "columnNumber",
+                            "description": "Column number in the script (0-based).",
+                            "type": "integer"
+                        }
                     ]
                 },
                 {
@@ -15669,6 +18499,48 @@
                             "name": "reason",
                             "description": "Not restored reason",
                             "$ref": "BackForwardCacheNotRestoredReason"
+                        },
+                        {
+                            "name": "context",
+                            "description": "Context associated with the reason. The meaning of this context is\ndependent on the reason:\n- EmbedderExtensionSentMessageToCachedFrame: the extension ID.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "details",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "BackForwardCacheBlockingDetails"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "BackForwardCacheNotRestoredExplanationTree",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "url",
+                            "description": "URL of each frame",
+                            "type": "string"
+                        },
+                        {
+                            "name": "explanations",
+                            "description": "Not restored reasons of each frame",
+                            "type": "array",
+                            "items": {
+                                "$ref": "BackForwardCacheNotRestoredExplanation"
+                            }
+                        },
+                        {
+                            "name": "children",
+                            "description": "Array of children frame",
+                            "type": "array",
+                            "items": {
+                                "$ref": "BackForwardCacheNotRestoredExplanationTree"
+                            }
                         }
                     ]
                 }
@@ -15711,6 +18583,13 @@
                         {
                             "name": "includeCommandLineAPI",
                             "description": "Specifies whether command line API should be available to the script, defaults\nto false.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "runImmediately",
+                            "description": "If true, runs the script immediately on existing execution contexts or worlds.\nDefault: false.",
                             "experimental": true,
                             "optional": true,
                             "type": "boolean"
@@ -15765,6 +18644,13 @@
                         {
                             "name": "captureBeyondViewport",
                             "description": "Capture the screenshot beyond the viewport. Defaults to false.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "optimizeForSpeed",
+                            "description": "Optimize image encoding for speed, not for resulting size (defaults to false)",
                             "experimental": true,
                             "optional": true,
                             "type": "boolean"
@@ -15880,6 +18766,14 @@
                 },
                 {
                     "name": "getAppManifest",
+                    "description": "Gets the processed manifest for this current document.\n  This API always waits for the manifest to be loaded.\n  If manifestId is provided, and it does not match the manifest of the\n    current document, this API errors out.\n  If there is not a loaded page, this API errors out immediately.",
+                    "parameters": [
+                        {
+                            "name": "manifestId",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ],
                     "returns": [
                         {
                             "name": "url",
@@ -15901,10 +18795,16 @@
                         },
                         {
                             "name": "parsed",
-                            "description": "Parsed manifest properties",
+                            "description": "Parsed manifest properties. Deprecated, use manifest instead.",
                             "experimental": true,
+                            "deprecated": true,
                             "optional": true,
                             "$ref": "AppManifestParsedProperties"
+                        },
+                        {
+                            "name": "manifest",
+                            "experimental": true,
+                            "$ref": "WebAppManifest"
                         }
                     ]
                 },
@@ -15923,7 +18823,9 @@
                 },
                 {
                     "name": "getManifestIcons",
+                    "description": "Deprecated because it's not guaranteed that the returned icon is in fact the one used for PWA installation.",
                     "experimental": true,
+                    "deprecated": true,
                     "returns": [
                         {
                             "name": "primaryIcon",
@@ -15952,19 +18854,20 @@
                     ]
                 },
                 {
-                    "name": "getCookies",
-                    "description": "Returns all browser cookies. Depending on the backend support, will return detailed cookie\ninformation in the `cookies` field.",
+                    "name": "getAdScriptId",
                     "experimental": true,
-                    "deprecated": true,
-                    "redirect": "Network",
+                    "parameters": [
+                        {
+                            "name": "frameId",
+                            "$ref": "FrameId"
+                        }
+                    ],
                     "returns": [
                         {
-                            "name": "cookies",
-                            "description": "Array of cookie objects.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "Network.Cookie"
-                            }
+                            "name": "adScriptId",
+                            "description": "Identifies the bottom-most script which caused the frame to be labelled\nas an ad. Only sent if frame is labelled as an ad and id is available.",
+                            "optional": true,
+                            "$ref": "AdScriptId"
                         }
                     ]
                 },
@@ -15985,19 +18888,19 @@
                     "returns": [
                         {
                             "name": "layoutViewport",
-                            "description": "Deprecated metrics relating to the layout viewport. Can be in DP or in CSS pixels depending on the `enable-use-zoom-for-dsf` flag. Use `cssLayoutViewport` instead.",
+                            "description": "Deprecated metrics relating to the layout viewport. Is in device pixels. Use `cssLayoutViewport` instead.",
                             "deprecated": true,
                             "$ref": "LayoutViewport"
                         },
                         {
                             "name": "visualViewport",
-                            "description": "Deprecated metrics relating to the visual viewport. Can be in DP or in CSS pixels depending on the `enable-use-zoom-for-dsf` flag. Use `cssVisualViewport` instead.",
+                            "description": "Deprecated metrics relating to the visual viewport. Is in device pixels. Use `cssVisualViewport` instead.",
                             "deprecated": true,
                             "$ref": "VisualViewport"
                         },
                         {
                             "name": "contentSize",
-                            "description": "Deprecated size of scrollable area. Can be in DP or in CSS pixels depending on the `enable-use-zoom-for-dsf` flag. Use `cssContentSize` instead.",
+                            "description": "Deprecated size of scrollable area. Is in DP. Use `cssContentSize` instead.",
                             "deprecated": true,
                             "$ref": "DOM.Rect"
                         },
@@ -16142,7 +19045,7 @@
                         },
                         {
                             "name": "loaderId",
-                            "description": "Loader identifier.",
+                            "description": "Loader identifier. This is omitted in case of same-document navigation,\nas the previously committed loaderId would not change.",
                             "optional": true,
                             "$ref": "Network.LoaderId"
                         },
@@ -16231,15 +19134,9 @@
                         },
                         {
                             "name": "pageRanges",
-                            "description": "Paper ranges to print, e.g., '1-5, 8, 11-13'. Defaults to the empty string, which means\nprint all pages.",
+                            "description": "Paper ranges to print, one based, e.g., '1-5, 8, 11-13'. Pages are\nprinted in the document order, not in the order specified, and no\nmore than once.\nDefaults to empty string, which implies the entire document is printed.\nThe page numbers are quietly capped to actual page count of the\ndocument, and ranges beyond the end of the document are ignored.\nIf this results in no pages to print, an error is reported.\nIt is an error to specify a range with start greater than end.",
                             "optional": true,
                             "type": "string"
-                        },
-                        {
-                            "name": "ignoreInvalidPageRanges",
-                            "description": "Whether to silently ignore invalid but successfully parsed page ranges, such as '3-2'.\nDefaults to false.",
-                            "optional": true,
-                            "type": "boolean"
                         },
                         {
                             "name": "headerTemplate",
@@ -16269,6 +19166,20 @@
                                 "ReturnAsBase64",
                                 "ReturnAsStream"
                             ]
+                        },
+                        {
+                            "name": "generateTaggedPDF",
+                            "description": "Whether or not to generate tagged (accessible) PDF. Defaults to embedder choice.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "generateDocumentOutline",
+                            "description": "Whether or not to embed the document outline into the PDF.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ],
                     "returns": [
@@ -16301,6 +19212,13 @@
                             "description": "If set, the script will be injected into all frames of the inspected page after reload.\nArgument will be ignored if reloading dataURL origin.",
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "loaderId",
+                            "description": "If set, an error will be thrown if the target page's main frame's\nloader id does not match the provided id. This prevents accidentally\nreloading an unintended target in case there's a racing navigation.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "Network.LoaderId"
                         }
                     ]
                 },
@@ -16397,7 +19315,6 @@
                 {
                     "name": "setBypassCSP",
                     "description": "Enable page Content Security Policy by-passing.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "enabled",
@@ -16556,6 +19473,15 @@
                             "name": "fontFamilies",
                             "description": "Specifies font families to set. If a font family is not specified, it won't be changed.",
                             "$ref": "FontFamilies"
+                        },
+                        {
+                            "name": "forScripts",
+                            "description": "Specifies font families to set for individual scripts.",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "ScriptFontFamilies"
+                            }
                         }
                     ]
                 },
@@ -16640,7 +19566,6 @@
                 {
                     "name": "setLifecycleEventsEnabled",
                     "description": "Controls whether page will emit lifecycle events.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "enabled",
@@ -16725,8 +19650,7 @@
                 },
                 {
                     "name": "close",
-                    "description": "Tries to close page, running its beforeunload hooks, if any.",
-                    "experimental": true
+                    "description": "Tries to close page, running its beforeunload hooks, if any."
                 },
                 {
                     "name": "setWebLifecycleState",
@@ -16751,7 +19675,7 @@
                 },
                 {
                     "name": "produceCompilationCache",
-                    "description": "Requests backend to produce compilation cache for the specified scripts.\n`scripts` are appeneded to the list of scripts for which the cache\nwould be produced. The list may be reset during page navigation.\nWhen script with a matching URL is encountered, the cache is optionally\nproduced upon backend discretion, based on internal heuristics.\nSee also: `Page.compilationCacheProduced`.",
+                    "description": "Requests backend to produce compilation cache for the specified scripts.\n`scripts` are appended to the list of scripts for which the cache\nwould be produced. The list may be reset during page navigation.\nWhen script with a matching URL is encountered, the cache is optionally\nproduced upon backend discretion, based on internal heuristics.\nSee also: `Page.compilationCacheProduced`.",
                     "experimental": true,
                     "parameters": [
                         {
@@ -16791,12 +19715,18 @@
                     "parameters": [
                         {
                             "name": "mode",
-                            "type": "string",
-                            "enum": [
-                                "none",
-                                "autoaccept",
-                                "autoreject"
-                            ]
+                            "$ref": "AutoResponseMode"
+                        }
+                    ]
+                },
+                {
+                    "name": "setRPHRegistrationMode",
+                    "description": "Extensions for Custom Handlers API:\nhttps://html.spec.whatwg.org/multipage/system-state.html#rph-automation",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "mode",
+                            "$ref": "AutoResponseMode"
                         }
                     ]
                 },
@@ -16826,10 +19756,20 @@
                 {
                     "name": "setInterceptFileChooserDialog",
                     "description": "Intercept file chooser requests and transfer control to protocol clients.\nWhen file chooser interception is enabled, native file chooser dialog is not shown.\nInstead, a protocol event `Page.fileChooserOpened` is emitted.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "enabled",
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "name": "setPrerenderingAllowed",
+                    "description": "Enable/disable prerendering manually.\n\nThis command is a short-term solution for https://crbug.com/1440085.\nSee https://docs.google.com/document/d/12HVmFxYj5Jc-eJr5OmWsa2bqTJsbgGLKI6ZIyx0_wpA\nfor more details.\n\nTODO(https://crbug.com/1440085): Remove this once Puppeteer supports tab targets.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "isAllowed",
                             "type": "boolean"
                         }
                     ]
@@ -16856,12 +19796,6 @@
                             "$ref": "FrameId"
                         },
                         {
-                            "name": "backendNodeId",
-                            "description": "Input node id.",
-                            "experimental": true,
-                            "$ref": "DOM.BackendNodeId"
-                        },
-                        {
                             "name": "mode",
                             "description": "Input mode.",
                             "type": "string",
@@ -16869,6 +19803,13 @@
                                 "selectSingle",
                                 "selectMultiple"
                             ]
+                        },
+                        {
+                            "name": "backendNodeId",
+                            "description": "Input node id. Only present for file choosers opened via an `<input type=\"file\">` element.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "DOM.BackendNodeId"
                         }
                     ]
                 },
@@ -17184,7 +20125,7 @@
                     "parameters": [
                         {
                             "name": "loaderId",
-                            "description": "The loader id for the associated navgation.",
+                            "description": "The loader id for the associated navigation.",
                             "$ref": "Network.LoaderId"
                         },
                         {
@@ -17199,6 +20140,12 @@
                             "items": {
                                 "$ref": "BackForwardCacheNotRestoredExplanation"
                             }
+                        },
+                        {
+                            "name": "notRestoredExplanationsTree",
+                            "description": "Tree structure of reasons why the page could not be cached for each frame.",
+                            "optional": true,
+                            "$ref": "BackForwardCacheNotRestoredExplanationTree"
                         }
                     ]
                 },
@@ -17508,7 +20455,7 @@
                         },
                         {
                             "name": "type",
-                            "description": "The event type, as specified in https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype\nThis determines which of the optional \"details\" fiedls is present.",
+                            "description": "The event type, as specified in https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype\nThis determines which of the optional \"details\" fields is present.",
                             "type": "string"
                         },
                         {
@@ -17670,7 +20617,7 @@
                         },
                         {
                             "name": "certificateHasWeakSignature",
-                            "description": "True if the certificate uses a weak signature aglorithm.",
+                            "description": "True if the certificate uses a weak signature algorithm.",
                             "type": "boolean"
                         },
                         {
@@ -17879,7 +20826,6 @@
                 {
                     "name": "setIgnoreCertificateErrors",
                     "description": "Enable/disable whether all certificate errors should be ignored.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "ignore",
@@ -18096,6 +21042,11 @@
                             "name": "targetId",
                             "optional": true,
                             "$ref": "Target.TargetID"
+                        },
+                        {
+                            "name": "routerRules",
+                            "optional": true,
+                            "type": "string"
                         }
                     ]
                 },
@@ -18305,6 +21256,10 @@
             ],
             "types": [
                 {
+                    "id": "SerializedStorageKey",
+                    "type": "string"
+                },
+                {
                     "id": "StorageType",
                     "description": "Enum of possible storage types.",
                     "type": "string",
@@ -18318,6 +21273,9 @@
                         "websql",
                         "service_workers",
                         "cache_storage",
+                        "interest_groups",
+                        "shared_storage",
+                        "storage_buckets",
                         "all",
                         "other"
                     ]
@@ -18354,9 +21312,844 @@
                             "type": "number"
                         }
                     ]
+                },
+                {
+                    "id": "InterestGroupAuctionId",
+                    "description": "Protected audience interest group auction identifier.",
+                    "type": "string"
+                },
+                {
+                    "id": "InterestGroupAccessType",
+                    "description": "Enum of interest group access types.",
+                    "type": "string",
+                    "enum": [
+                        "join",
+                        "leave",
+                        "update",
+                        "loaded",
+                        "bid",
+                        "win",
+                        "additionalBid",
+                        "additionalBidWin",
+                        "topLevelBid",
+                        "topLevelAdditionalBid",
+                        "clear"
+                    ]
+                },
+                {
+                    "id": "InterestGroupAuctionEventType",
+                    "description": "Enum of auction events.",
+                    "type": "string",
+                    "enum": [
+                        "started",
+                        "configResolved"
+                    ]
+                },
+                {
+                    "id": "InterestGroupAuctionFetchType",
+                    "description": "Enum of network fetches auctions can do.",
+                    "type": "string",
+                    "enum": [
+                        "bidderJs",
+                        "bidderWasm",
+                        "sellerJs",
+                        "bidderTrustedSignals",
+                        "sellerTrustedSignals"
+                    ]
+                },
+                {
+                    "id": "SharedStorageAccessType",
+                    "description": "Enum of shared storage access types.",
+                    "type": "string",
+                    "enum": [
+                        "documentAddModule",
+                        "documentSelectURL",
+                        "documentRun",
+                        "documentSet",
+                        "documentAppend",
+                        "documentDelete",
+                        "documentClear",
+                        "documentGet",
+                        "workletSet",
+                        "workletAppend",
+                        "workletDelete",
+                        "workletClear",
+                        "workletGet",
+                        "workletKeys",
+                        "workletEntries",
+                        "workletLength",
+                        "workletRemainingBudget",
+                        "headerSet",
+                        "headerAppend",
+                        "headerDelete",
+                        "headerClear"
+                    ]
+                },
+                {
+                    "id": "SharedStorageEntry",
+                    "description": "Struct for a single key-value pair in an origin's shared storage.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "key",
+                            "type": "string"
+                        },
+                        {
+                            "name": "value",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "SharedStorageMetadata",
+                    "description": "Details for an origin's shared storage.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "creationTime",
+                            "description": "Time when the origin's shared storage was last created.",
+                            "$ref": "Network.TimeSinceEpoch"
+                        },
+                        {
+                            "name": "length",
+                            "description": "Number of key-value pairs stored in origin's shared storage.",
+                            "type": "integer"
+                        },
+                        {
+                            "name": "remainingBudget",
+                            "description": "Current amount of bits of entropy remaining in the navigation budget.",
+                            "type": "number"
+                        },
+                        {
+                            "name": "bytesUsed",
+                            "description": "Total number of bytes stored as key-value pairs in origin's shared\nstorage.",
+                            "type": "integer"
+                        }
+                    ]
+                },
+                {
+                    "id": "SharedStorageReportingMetadata",
+                    "description": "Pair of reporting metadata details for a candidate URL for `selectURL()`.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "eventType",
+                            "type": "string"
+                        },
+                        {
+                            "name": "reportingUrl",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "SharedStorageUrlWithMetadata",
+                    "description": "Bundles a candidate URL with its reporting metadata.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "url",
+                            "description": "Spec of candidate URL.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "reportingMetadata",
+                            "description": "Any associated reporting metadata.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "SharedStorageReportingMetadata"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "SharedStorageAccessParams",
+                    "description": "Bundles the parameters for shared storage access events whose\npresence/absence can vary according to SharedStorageAccessType.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "scriptSourceUrl",
+                            "description": "Spec of the module script URL.\nPresent only for SharedStorageAccessType.documentAddModule.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "operationName",
+                            "description": "Name of the registered operation to be run.\nPresent only for SharedStorageAccessType.documentRun and\nSharedStorageAccessType.documentSelectURL.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "serializedData",
+                            "description": "The operation's serialized data in bytes (converted to a string).\nPresent only for SharedStorageAccessType.documentRun and\nSharedStorageAccessType.documentSelectURL.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "urlsWithMetadata",
+                            "description": "Array of candidate URLs' specs, along with any associated metadata.\nPresent only for SharedStorageAccessType.documentSelectURL.",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "SharedStorageUrlWithMetadata"
+                            }
+                        },
+                        {
+                            "name": "key",
+                            "description": "Key for a specific entry in an origin's shared storage.\nPresent only for SharedStorageAccessType.documentSet,\nSharedStorageAccessType.documentAppend,\nSharedStorageAccessType.documentDelete,\nSharedStorageAccessType.workletSet,\nSharedStorageAccessType.workletAppend,\nSharedStorageAccessType.workletDelete,\nSharedStorageAccessType.workletGet,\nSharedStorageAccessType.headerSet,\nSharedStorageAccessType.headerAppend, and\nSharedStorageAccessType.headerDelete.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "value",
+                            "description": "Value for a specific entry in an origin's shared storage.\nPresent only for SharedStorageAccessType.documentSet,\nSharedStorageAccessType.documentAppend,\nSharedStorageAccessType.workletSet,\nSharedStorageAccessType.workletAppend,\nSharedStorageAccessType.headerSet, and\nSharedStorageAccessType.headerAppend.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "ignoreIfPresent",
+                            "description": "Whether or not to set an entry for a key if that key is already present.\nPresent only for SharedStorageAccessType.documentSet,\nSharedStorageAccessType.workletSet, and\nSharedStorageAccessType.headerSet.",
+                            "optional": true,
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "id": "StorageBucketsDurability",
+                    "type": "string",
+                    "enum": [
+                        "relaxed",
+                        "strict"
+                    ]
+                },
+                {
+                    "id": "StorageBucket",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "storageKey",
+                            "$ref": "SerializedStorageKey"
+                        },
+                        {
+                            "name": "name",
+                            "description": "If not specified, it is the default bucket of the storageKey.",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "StorageBucketInfo",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "bucket",
+                            "$ref": "StorageBucket"
+                        },
+                        {
+                            "name": "id",
+                            "type": "string"
+                        },
+                        {
+                            "name": "expiration",
+                            "$ref": "Network.TimeSinceEpoch"
+                        },
+                        {
+                            "name": "quota",
+                            "description": "Storage quota (bytes).",
+                            "type": "number"
+                        },
+                        {
+                            "name": "persistent",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "durability",
+                            "$ref": "StorageBucketsDurability"
+                        }
+                    ]
+                },
+                {
+                    "id": "AttributionReportingSourceType",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "navigation",
+                        "event"
+                    ]
+                },
+                {
+                    "id": "UnsignedInt64AsBase10",
+                    "experimental": true,
+                    "type": "string"
+                },
+                {
+                    "id": "UnsignedInt128AsBase16",
+                    "experimental": true,
+                    "type": "string"
+                },
+                {
+                    "id": "SignedInt64AsBase10",
+                    "experimental": true,
+                    "type": "string"
+                },
+                {
+                    "id": "AttributionReportingFilterDataEntry",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "key",
+                            "type": "string"
+                        },
+                        {
+                            "name": "values",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "AttributionReportingFilterConfig",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "filterValues",
+                            "type": "array",
+                            "items": {
+                                "$ref": "AttributionReportingFilterDataEntry"
+                            }
+                        },
+                        {
+                            "name": "lookbackWindow",
+                            "description": "duration in seconds",
+                            "optional": true,
+                            "type": "integer"
+                        }
+                    ]
+                },
+                {
+                    "id": "AttributionReportingFilterPair",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "filters",
+                            "type": "array",
+                            "items": {
+                                "$ref": "AttributionReportingFilterConfig"
+                            }
+                        },
+                        {
+                            "name": "notFilters",
+                            "type": "array",
+                            "items": {
+                                "$ref": "AttributionReportingFilterConfig"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "AttributionReportingAggregationKeysEntry",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "key",
+                            "type": "string"
+                        },
+                        {
+                            "name": "value",
+                            "$ref": "UnsignedInt128AsBase16"
+                        }
+                    ]
+                },
+                {
+                    "id": "AttributionReportingEventReportWindows",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "start",
+                            "description": "duration in seconds",
+                            "type": "integer"
+                        },
+                        {
+                            "name": "ends",
+                            "description": "duration in seconds",
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "AttributionReportingTriggerSpec",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "triggerData",
+                            "description": "number instead of integer because not all uint32 can be represented by\nint",
+                            "type": "array",
+                            "items": {
+                                "type": "number"
+                            }
+                        },
+                        {
+                            "name": "eventReportWindows",
+                            "$ref": "AttributionReportingEventReportWindows"
+                        }
+                    ]
+                },
+                {
+                    "id": "AttributionReportingTriggerDataMatching",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "exact",
+                        "modulus"
+                    ]
+                },
+                {
+                    "id": "AttributionReportingAggregatableDebugReportingData",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "keyPiece",
+                            "$ref": "UnsignedInt128AsBase16"
+                        },
+                        {
+                            "name": "value",
+                            "description": "number instead of integer because not all uint32 can be represented by\nint",
+                            "type": "number"
+                        },
+                        {
+                            "name": "types",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "AttributionReportingAggregatableDebugReportingConfig",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "budget",
+                            "description": "number instead of integer because not all uint32 can be represented by\nint, only present for source registrations",
+                            "optional": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "keyPiece",
+                            "$ref": "UnsignedInt128AsBase16"
+                        },
+                        {
+                            "name": "debugData",
+                            "type": "array",
+                            "items": {
+                                "$ref": "AttributionReportingAggregatableDebugReportingData"
+                            }
+                        },
+                        {
+                            "name": "aggregationCoordinatorOrigin",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "AttributionReportingSourceRegistration",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "time",
+                            "$ref": "Network.TimeSinceEpoch"
+                        },
+                        {
+                            "name": "expiry",
+                            "description": "duration in seconds",
+                            "type": "integer"
+                        },
+                        {
+                            "name": "triggerSpecs",
+                            "type": "array",
+                            "items": {
+                                "$ref": "AttributionReportingTriggerSpec"
+                            }
+                        },
+                        {
+                            "name": "aggregatableReportWindow",
+                            "description": "duration in seconds",
+                            "type": "integer"
+                        },
+                        {
+                            "name": "type",
+                            "$ref": "AttributionReportingSourceType"
+                        },
+                        {
+                            "name": "sourceOrigin",
+                            "type": "string"
+                        },
+                        {
+                            "name": "reportingOrigin",
+                            "type": "string"
+                        },
+                        {
+                            "name": "destinationSites",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "name": "eventId",
+                            "$ref": "UnsignedInt64AsBase10"
+                        },
+                        {
+                            "name": "priority",
+                            "$ref": "SignedInt64AsBase10"
+                        },
+                        {
+                            "name": "filterData",
+                            "type": "array",
+                            "items": {
+                                "$ref": "AttributionReportingFilterDataEntry"
+                            }
+                        },
+                        {
+                            "name": "aggregationKeys",
+                            "type": "array",
+                            "items": {
+                                "$ref": "AttributionReportingAggregationKeysEntry"
+                            }
+                        },
+                        {
+                            "name": "debugKey",
+                            "optional": true,
+                            "$ref": "UnsignedInt64AsBase10"
+                        },
+                        {
+                            "name": "triggerDataMatching",
+                            "$ref": "AttributionReportingTriggerDataMatching"
+                        },
+                        {
+                            "name": "destinationLimitPriority",
+                            "$ref": "SignedInt64AsBase10"
+                        },
+                        {
+                            "name": "aggregatableDebugReportingConfig",
+                            "$ref": "AttributionReportingAggregatableDebugReportingConfig"
+                        }
+                    ]
+                },
+                {
+                    "id": "AttributionReportingSourceRegistrationResult",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "success",
+                        "internalError",
+                        "insufficientSourceCapacity",
+                        "insufficientUniqueDestinationCapacity",
+                        "excessiveReportingOrigins",
+                        "prohibitedByBrowserPolicy",
+                        "successNoised",
+                        "destinationReportingLimitReached",
+                        "destinationGlobalLimitReached",
+                        "destinationBothLimitsReached",
+                        "reportingOriginsPerSiteLimitReached",
+                        "exceedsMaxChannelCapacity",
+                        "exceedsMaxTriggerStateCardinality",
+                        "destinationPerDayReportingLimitReached"
+                    ]
+                },
+                {
+                    "id": "AttributionReportingSourceRegistrationTimeConfig",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "include",
+                        "exclude"
+                    ]
+                },
+                {
+                    "id": "AttributionReportingAggregatableValueDictEntry",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "key",
+                            "type": "string"
+                        },
+                        {
+                            "name": "value",
+                            "description": "number instead of integer because not all uint32 can be represented by\nint",
+                            "type": "number"
+                        },
+                        {
+                            "name": "filteringId",
+                            "$ref": "UnsignedInt64AsBase10"
+                        }
+                    ]
+                },
+                {
+                    "id": "AttributionReportingAggregatableValueEntry",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "values",
+                            "type": "array",
+                            "items": {
+                                "$ref": "AttributionReportingAggregatableValueDictEntry"
+                            }
+                        },
+                        {
+                            "name": "filters",
+                            "$ref": "AttributionReportingFilterPair"
+                        }
+                    ]
+                },
+                {
+                    "id": "AttributionReportingEventTriggerData",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "data",
+                            "$ref": "UnsignedInt64AsBase10"
+                        },
+                        {
+                            "name": "priority",
+                            "$ref": "SignedInt64AsBase10"
+                        },
+                        {
+                            "name": "dedupKey",
+                            "optional": true,
+                            "$ref": "UnsignedInt64AsBase10"
+                        },
+                        {
+                            "name": "filters",
+                            "$ref": "AttributionReportingFilterPair"
+                        }
+                    ]
+                },
+                {
+                    "id": "AttributionReportingAggregatableTriggerData",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "keyPiece",
+                            "$ref": "UnsignedInt128AsBase16"
+                        },
+                        {
+                            "name": "sourceKeys",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "name": "filters",
+                            "$ref": "AttributionReportingFilterPair"
+                        }
+                    ]
+                },
+                {
+                    "id": "AttributionReportingAggregatableDedupKey",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "dedupKey",
+                            "optional": true,
+                            "$ref": "UnsignedInt64AsBase10"
+                        },
+                        {
+                            "name": "filters",
+                            "$ref": "AttributionReportingFilterPair"
+                        }
+                    ]
+                },
+                {
+                    "id": "AttributionReportingTriggerRegistration",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "filters",
+                            "$ref": "AttributionReportingFilterPair"
+                        },
+                        {
+                            "name": "debugKey",
+                            "optional": true,
+                            "$ref": "UnsignedInt64AsBase10"
+                        },
+                        {
+                            "name": "aggregatableDedupKeys",
+                            "type": "array",
+                            "items": {
+                                "$ref": "AttributionReportingAggregatableDedupKey"
+                            }
+                        },
+                        {
+                            "name": "eventTriggerData",
+                            "type": "array",
+                            "items": {
+                                "$ref": "AttributionReportingEventTriggerData"
+                            }
+                        },
+                        {
+                            "name": "aggregatableTriggerData",
+                            "type": "array",
+                            "items": {
+                                "$ref": "AttributionReportingAggregatableTriggerData"
+                            }
+                        },
+                        {
+                            "name": "aggregatableValues",
+                            "type": "array",
+                            "items": {
+                                "$ref": "AttributionReportingAggregatableValueEntry"
+                            }
+                        },
+                        {
+                            "name": "aggregatableFilteringIdMaxBytes",
+                            "type": "integer"
+                        },
+                        {
+                            "name": "debugReporting",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "aggregationCoordinatorOrigin",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "sourceRegistrationTimeConfig",
+                            "$ref": "AttributionReportingSourceRegistrationTimeConfig"
+                        },
+                        {
+                            "name": "triggerContextId",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "aggregatableDebugReportingConfig",
+                            "$ref": "AttributionReportingAggregatableDebugReportingConfig"
+                        }
+                    ]
+                },
+                {
+                    "id": "AttributionReportingEventLevelResult",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "success",
+                        "successDroppedLowerPriority",
+                        "internalError",
+                        "noCapacityForAttributionDestination",
+                        "noMatchingSources",
+                        "deduplicated",
+                        "excessiveAttributions",
+                        "priorityTooLow",
+                        "neverAttributedSource",
+                        "excessiveReportingOrigins",
+                        "noMatchingSourceFilterData",
+                        "prohibitedByBrowserPolicy",
+                        "noMatchingConfigurations",
+                        "excessiveReports",
+                        "falselyAttributedSource",
+                        "reportWindowPassed",
+                        "notRegistered",
+                        "reportWindowNotStarted",
+                        "noMatchingTriggerData"
+                    ]
+                },
+                {
+                    "id": "AttributionReportingAggregatableResult",
+                    "experimental": true,
+                    "type": "string",
+                    "enum": [
+                        "success",
+                        "internalError",
+                        "noCapacityForAttributionDestination",
+                        "noMatchingSources",
+                        "excessiveAttributions",
+                        "excessiveReportingOrigins",
+                        "noHistograms",
+                        "insufficientBudget",
+                        "noMatchingSourceFilterData",
+                        "notRegistered",
+                        "prohibitedByBrowserPolicy",
+                        "deduplicated",
+                        "reportWindowPassed",
+                        "excessiveReports"
+                    ]
+                },
+                {
+                    "id": "RelatedWebsiteSet",
+                    "description": "A single Related Website Set object.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "primarySites",
+                            "description": "The primary site of this set, along with the ccTLDs if there is any.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "name": "associatedSites",
+                            "description": "The associated sites of this set, along with the ccTLDs if there is any.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "name": "serviceSites",
+                            "description": "The service sites of this set, along with the ccTLDs if there is any.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
                 }
             ],
             "commands": [
+                {
+                    "name": "getStorageKeyForFrame",
+                    "description": "Returns a storage key given a frame id.",
+                    "parameters": [
+                        {
+                            "name": "frameId",
+                            "$ref": "Page.FrameId"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "storageKey",
+                            "$ref": "SerializedStorageKey"
+                        }
+                    ]
+                },
                 {
                     "name": "clearDataForOrigin",
                     "description": "Clears storage for origin.",
@@ -18364,6 +22157,22 @@
                         {
                             "name": "origin",
                             "description": "Security origin.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "storageTypes",
+                            "description": "Comma separated list of StorageType to clear.",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "clearDataForStorageKey",
+                    "description": "Clears storage for storage key.",
+                    "parameters": [
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key.",
                             "type": "string"
                         },
                         {
@@ -18493,12 +22302,34 @@
                     ]
                 },
                 {
+                    "name": "trackCacheStorageForStorageKey",
+                    "description": "Registers storage key to be notified when an update occurs to its cache storage list.",
+                    "parameters": [
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key.",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
                     "name": "trackIndexedDBForOrigin",
                     "description": "Registers origin to be notified when an update occurs to its IndexedDB.",
                     "parameters": [
                         {
                             "name": "origin",
                             "description": "Security origin.",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "trackIndexedDBForStorageKey",
+                    "description": "Registers storage key to be notified when an update occurs to its IndexedDB.",
+                    "parameters": [
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key.",
                             "type": "string"
                         }
                     ]
@@ -18515,12 +22346,34 @@
                     ]
                 },
                 {
+                    "name": "untrackCacheStorageForStorageKey",
+                    "description": "Unregisters storage key from receiving notifications for cache storage.",
+                    "parameters": [
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key.",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
                     "name": "untrackIndexedDBForOrigin",
                     "description": "Unregisters origin from receiving notifications for IndexedDB.",
                     "parameters": [
                         {
                             "name": "origin",
                             "description": "Security origin.",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "untrackIndexedDBForStorageKey",
+                    "description": "Unregisters storage key from receiving notifications for IndexedDB.",
+                    "parameters": [
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key.",
                             "type": "string"
                         }
                     ]
@@ -18556,6 +22409,249 @@
                             "type": "boolean"
                         }
                     ]
+                },
+                {
+                    "name": "getInterestGroupDetails",
+                    "description": "Gets details for a named interest group.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "ownerOrigin",
+                            "type": "string"
+                        },
+                        {
+                            "name": "name",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "details",
+                            "description": "This largely corresponds to:\nhttps://wicg.github.io/turtledove/#dictdef-generatebidinterestgroup\nbut has absolute expirationTime instead of relative lifetimeMs and\nalso adds joiningOrigin.",
+                            "type": "object"
+                        }
+                    ]
+                },
+                {
+                    "name": "setInterestGroupTracking",
+                    "description": "Enables/Disables issuing of interestGroupAccessed events.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "enable",
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "name": "setInterestGroupAuctionTracking",
+                    "description": "Enables/Disables issuing of interestGroupAuctionEventOccurred and\ninterestGroupAuctionNetworkRequestCreated.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "enable",
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "name": "getSharedStorageMetadata",
+                    "description": "Gets metadata for an origin's shared storage.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "ownerOrigin",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "metadata",
+                            "$ref": "SharedStorageMetadata"
+                        }
+                    ]
+                },
+                {
+                    "name": "getSharedStorageEntries",
+                    "description": "Gets the entries in an given origin's shared storage.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "ownerOrigin",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "entries",
+                            "type": "array",
+                            "items": {
+                                "$ref": "SharedStorageEntry"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "setSharedStorageEntry",
+                    "description": "Sets entry with `key` and `value` for a given origin's shared storage.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "ownerOrigin",
+                            "type": "string"
+                        },
+                        {
+                            "name": "key",
+                            "type": "string"
+                        },
+                        {
+                            "name": "value",
+                            "type": "string"
+                        },
+                        {
+                            "name": "ignoreIfPresent",
+                            "description": "If `ignoreIfPresent` is included and true, then only sets the entry if\n`key` doesn't already exist.",
+                            "optional": true,
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "name": "deleteSharedStorageEntry",
+                    "description": "Deletes entry for `key` (if it exists) for a given origin's shared storage.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "ownerOrigin",
+                            "type": "string"
+                        },
+                        {
+                            "name": "key",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "clearSharedStorageEntries",
+                    "description": "Clears all entries for a given origin's shared storage.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "ownerOrigin",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "resetSharedStorageBudget",
+                    "description": "Resets the budget for `ownerOrigin` by clearing all budget withdrawals.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "ownerOrigin",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "setSharedStorageTracking",
+                    "description": "Enables/disables issuing of sharedStorageAccessed events.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "enable",
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "name": "setStorageBucketTracking",
+                    "description": "Set tracking for a storage key's buckets.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "storageKey",
+                            "type": "string"
+                        },
+                        {
+                            "name": "enable",
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "name": "deleteStorageBucket",
+                    "description": "Deletes the Storage Bucket with the given storage key and bucket name.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "bucket",
+                            "$ref": "StorageBucket"
+                        }
+                    ]
+                },
+                {
+                    "name": "runBounceTrackingMitigations",
+                    "description": "Deletes state for sites identified as potential bounce trackers, immediately.",
+                    "experimental": true,
+                    "returns": [
+                        {
+                            "name": "deletedSites",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "setAttributionReportingLocalTestingMode",
+                    "description": "https://wicg.github.io/attribution-reporting-api/",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "enabled",
+                            "description": "If enabled, noise is suppressed and reports are sent immediately.",
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "name": "setAttributionReportingTracking",
+                    "description": "Enables/disables issuing of Attribution Reporting events.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "enable",
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "name": "sendPendingAttributionReports",
+                    "description": "Sends all pending Attribution Reports immediately, regardless of their\nscheduled report time.",
+                    "experimental": true,
+                    "returns": [
+                        {
+                            "name": "numSent",
+                            "description": "The number of reports that were sent.",
+                            "type": "integer"
+                        }
+                    ]
+                },
+                {
+                    "name": "getRelatedWebsiteSets",
+                    "description": "Returns the effective Related Website Sets in use by this profile for the browser\nsession. The effective Related Website Sets will not change during a browser session.",
+                    "experimental": true,
+                    "returns": [
+                        {
+                            "name": "sets",
+                            "type": "array",
+                            "items": {
+                                "$ref": "RelatedWebsiteSet"
+                            }
+                        }
+                    ]
                 }
             ],
             "events": [
@@ -18566,6 +22662,16 @@
                         {
                             "name": "origin",
                             "description": "Origin to update.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key to update.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "bucketId",
+                            "description": "Storage bucket to update.",
                             "type": "string"
                         },
                         {
@@ -18583,6 +22689,16 @@
                             "name": "origin",
                             "description": "Origin to update.",
                             "type": "string"
+                        },
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key to update.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "bucketId",
+                            "description": "Storage bucket to update.",
+                            "type": "string"
                         }
                     ]
                 },
@@ -18593,6 +22709,16 @@
                         {
                             "name": "origin",
                             "description": "Origin to update.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key to update.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "bucketId",
+                            "description": "Storage bucket to update.",
                             "type": "string"
                         },
                         {
@@ -18615,6 +22741,194 @@
                             "name": "origin",
                             "description": "Origin to update.",
                             "type": "string"
+                        },
+                        {
+                            "name": "storageKey",
+                            "description": "Storage key to update.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "bucketId",
+                            "description": "Storage bucket to update.",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "interestGroupAccessed",
+                    "description": "One of the interest groups was accessed. Note that these events are global\nto all targets sharing an interest group store.",
+                    "parameters": [
+                        {
+                            "name": "accessTime",
+                            "$ref": "Network.TimeSinceEpoch"
+                        },
+                        {
+                            "name": "type",
+                            "$ref": "InterestGroupAccessType"
+                        },
+                        {
+                            "name": "ownerOrigin",
+                            "type": "string"
+                        },
+                        {
+                            "name": "name",
+                            "type": "string"
+                        },
+                        {
+                            "name": "componentSellerOrigin",
+                            "description": "For topLevelBid/topLevelAdditionalBid, and when appropriate,\nwin and additionalBidWin",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "bid",
+                            "description": "For bid or somethingBid event, if done locally and not on a server.",
+                            "optional": true,
+                            "type": "number"
+                        },
+                        {
+                            "name": "bidCurrency",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "uniqueAuctionId",
+                            "description": "For non-global events --- links to interestGroupAuctionEvent",
+                            "optional": true,
+                            "$ref": "InterestGroupAuctionId"
+                        }
+                    ]
+                },
+                {
+                    "name": "interestGroupAuctionEventOccurred",
+                    "description": "An auction involving interest groups is taking place. These events are\ntarget-specific.",
+                    "parameters": [
+                        {
+                            "name": "eventTime",
+                            "$ref": "Network.TimeSinceEpoch"
+                        },
+                        {
+                            "name": "type",
+                            "$ref": "InterestGroupAuctionEventType"
+                        },
+                        {
+                            "name": "uniqueAuctionId",
+                            "$ref": "InterestGroupAuctionId"
+                        },
+                        {
+                            "name": "parentAuctionId",
+                            "description": "Set for child auctions.",
+                            "optional": true,
+                            "$ref": "InterestGroupAuctionId"
+                        },
+                        {
+                            "name": "auctionConfig",
+                            "description": "Set for started and configResolved",
+                            "optional": true,
+                            "type": "object"
+                        }
+                    ]
+                },
+                {
+                    "name": "interestGroupAuctionNetworkRequestCreated",
+                    "description": "Specifies which auctions a particular network fetch may be related to, and\nin what role. Note that it is not ordered with respect to\nNetwork.requestWillBeSent (but will happen before loadingFinished\nloadingFailed).",
+                    "parameters": [
+                        {
+                            "name": "type",
+                            "$ref": "InterestGroupAuctionFetchType"
+                        },
+                        {
+                            "name": "requestId",
+                            "$ref": "Network.RequestId"
+                        },
+                        {
+                            "name": "auctions",
+                            "description": "This is the set of the auctions using the worklet that issued this\nrequest.  In the case of trusted signals, it's possible that only some of\nthem actually care about the keys being queried.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "InterestGroupAuctionId"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "sharedStorageAccessed",
+                    "description": "Shared storage was accessed by the associated page.\nThe following parameters are included in all events.",
+                    "parameters": [
+                        {
+                            "name": "accessTime",
+                            "description": "Time of the access.",
+                            "$ref": "Network.TimeSinceEpoch"
+                        },
+                        {
+                            "name": "type",
+                            "description": "Enum value indicating the Shared Storage API method invoked.",
+                            "$ref": "SharedStorageAccessType"
+                        },
+                        {
+                            "name": "mainFrameId",
+                            "description": "DevTools Frame Token for the primary frame tree's root.",
+                            "$ref": "Page.FrameId"
+                        },
+                        {
+                            "name": "ownerOrigin",
+                            "description": "Serialized origin for the context that invoked the Shared Storage API.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "params",
+                            "description": "The sub-parameters wrapped by `params` are all optional and their\npresence/absence depends on `type`.",
+                            "$ref": "SharedStorageAccessParams"
+                        }
+                    ]
+                },
+                {
+                    "name": "storageBucketCreatedOrUpdated",
+                    "parameters": [
+                        {
+                            "name": "bucketInfo",
+                            "$ref": "StorageBucketInfo"
+                        }
+                    ]
+                },
+                {
+                    "name": "storageBucketDeleted",
+                    "parameters": [
+                        {
+                            "name": "bucketId",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "attributionReportingSourceRegistered",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "registration",
+                            "$ref": "AttributionReportingSourceRegistration"
+                        },
+                        {
+                            "name": "result",
+                            "$ref": "AttributionReportingSourceRegistrationResult"
+                        }
+                    ]
+                },
+                {
+                    "name": "attributionReportingTriggerRegistered",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "registration",
+                            "$ref": "AttributionReportingTriggerRegistration"
+                        },
+                        {
+                            "name": "eventLevel",
+                            "$ref": "AttributionReportingEventLevelResult"
+                        },
+                        {
+                            "name": "aggregatable",
+                            "$ref": "AttributionReportingAggregatableResult"
                         }
                     ]
                 }
@@ -18899,6 +23213,22 @@
                     ]
                 },
                 {
+                    "name": "getFeatureState",
+                    "description": "Returns information about the feature state.",
+                    "parameters": [
+                        {
+                            "name": "featureState",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "featureEnabled",
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
                     "name": "getProcessInfo",
                     "description": "Returns information about all running processes.",
                     "returns": [
@@ -18937,6 +23267,7 @@
                         },
                         {
                             "name": "type",
+                            "description": "List of types: https://source.chromium.org/chromium/chromium/src/+/main:content/browser/devtools/devtools_agent_host_impl.cc?ss=chromium&q=f:devtools%20-f:out%20%22::kTypeTab%5B%5D%22",
                             "type": "string"
                         },
                         {
@@ -18976,8 +23307,44 @@
                             "experimental": true,
                             "optional": true,
                             "$ref": "Browser.BrowserContextID"
+                        },
+                        {
+                            "name": "subtype",
+                            "description": "Provides additional details for specific target types. For example, for\nthe type of \"page\", this may be set to \"prerender\".",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "string"
                         }
                     ]
+                },
+                {
+                    "id": "FilterEntry",
+                    "description": "A filter used by target query/discovery/auto-attach operations.",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "exclude",
+                            "description": "If set, causes exclusion of matching targets from the list.",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "type",
+                            "description": "If not present, matches any type.",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "TargetFilter",
+                    "description": "The entries in TargetFilter are matched sequentially against targets and\nthe first entry that matches determines if the target is included or not,\ndepending on the value of `exclude` field in the entry.\nIf filter is not specified, the one assumed is\n[{type: \"browser\", exclude: true}, {type: \"tab\", exclude: true}, {}]\n(i.e. include everything but `browser` and `tab`).",
+                    "experimental": true,
+                    "type": "array",
+                    "items": {
+                        "$ref": "FilterEntry"
+                    }
                 },
                 {
                     "id": "RemoteLocation",
@@ -19061,7 +23428,7 @@
                 },
                 {
                     "name": "exposeDevToolsProtocol",
-                    "description": "Inject object to the target's main frame that provides a communication\nchannel with browser target.\n\nInjected object will be available as `window[bindingName]`.\n\nThe object has the follwing API:\n- `binding.send(json)` - a method to send messages over the remote debugging protocol\n- `binding.onmessage = json => handleMessage(json)` - a callback that will be called for the protocol notifications and command responses.",
+                    "description": "Inject object to the target's main frame that provides a communication\nchannel with browser target.\n\nInjected object will be available as `window[bindingName]`.\n\nThe object has the following API:\n- `binding.send(json)` - a method to send messages over the remote debugging protocol\n- `binding.onmessage = json => handleMessage(json)` - a callback that will be called for the protocol notifications and command responses.",
                     "experimental": true,
                     "parameters": [
                         {
@@ -19079,29 +23446,32 @@
                 {
                     "name": "createBrowserContext",
                     "description": "Creates a new empty BrowserContext. Similar to an incognito profile but you can have more than\none.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "disposeOnDetach",
                             "description": "If specified, disposes this context when debugging session disconnects.",
+                            "experimental": true,
                             "optional": true,
                             "type": "boolean"
                         },
                         {
                             "name": "proxyServer",
                             "description": "Proxy server, similar to the one passed to --proxy-server",
+                            "experimental": true,
                             "optional": true,
                             "type": "string"
                         },
                         {
                             "name": "proxyBypassList",
                             "description": "Proxy bypass list, similar to the one passed to --proxy-bypass-list",
+                            "experimental": true,
                             "optional": true,
                             "type": "string"
                         },
                         {
                             "name": "originsWithUniversalNetworkAccess",
-                            "description": "An optional list of origins to grant unlimited cross-origin access to.",
+                            "description": "An optional list of origins to grant unlimited cross-origin access to.\nParts of the URL other than those constituting origin are ignored.",
+                            "experimental": true,
                             "optional": true,
                             "type": "array",
                             "items": {
@@ -19120,7 +23490,6 @@
                 {
                     "name": "getBrowserContexts",
                     "description": "Returns all browser contexts created with `Target.createBrowserContext` method.",
-                    "experimental": true,
                     "returns": [
                         {
                             "name": "browserContextIds",
@@ -19178,6 +23547,13 @@
                             "description": "Whether to create the target in background or foreground (chrome-only,\nfalse by default).",
                             "optional": true,
                             "type": "boolean"
+                        },
+                        {
+                            "name": "forTab",
+                            "description": "Whether to create the target of type \"tab\".",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ],
                     "returns": [
@@ -19210,7 +23586,6 @@
                 {
                     "name": "disposeBrowserContext",
                     "description": "Deletes a BrowserContext. All the belonging pages will be closed without calling their\nbeforeunload hooks.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "browserContextId",
@@ -19239,6 +23614,15 @@
                 {
                     "name": "getTargets",
                     "description": "Retrieves a list of available targets.",
+                    "parameters": [
+                        {
+                            "name": "filter",
+                            "description": "Only targets matching filter will be reported. If filter is not specified\nand target discovery is currently enabled, a filter used for target discovery\nis used for consistency.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "TargetFilter"
+                        }
+                    ],
                     "returns": [
                         {
                             "name": "targetInfos",
@@ -19277,7 +23661,6 @@
                 {
                     "name": "setAutoAttach",
                     "description": "Controls whether to automatically attach to new targets which are considered to be related to\nthis one. When turned on, attaches to all existing related targets as well. When turned off,\nautomatically detaches from all currently attached targets.\nThis also clears all targets added by `autoAttachRelated` from the list of targets to watch\nfor creation of related targets.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "autoAttach",
@@ -19292,8 +23675,16 @@
                         {
                             "name": "flatten",
                             "description": "Enables \"flat\" access to the session via specifying sessionId attribute in the commands.\nWe plan to make this the default, deprecate non-flattened mode,\nand eventually retire it. See crbug.com/991325.",
+                            "experimental": true,
                             "optional": true,
                             "type": "boolean"
+                        },
+                        {
+                            "name": "filter",
+                            "description": "Only targets matching filter will be attached.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "TargetFilter"
                         }
                     ]
                 },
@@ -19310,6 +23701,13 @@
                             "name": "waitForDebuggerOnStart",
                             "description": "Whether to pause new targets when attaching to them. Use `Runtime.runIfWaitingForDebugger`\nto run paused targets.",
                             "type": "boolean"
+                        },
+                        {
+                            "name": "filter",
+                            "description": "Only targets matching filter will be attached.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "TargetFilter"
                         }
                     ]
                 },
@@ -19321,6 +23719,13 @@
                             "name": "discover",
                             "description": "Whether to discover available targets.",
                             "type": "boolean"
+                        },
+                        {
+                            "name": "filter",
+                            "description": "Only targets matching filter will be attached. If `discover` is false,\n`filter` must be omitted or empty.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "TargetFilter"
                         }
                     ]
                 },
@@ -19503,7 +23908,6 @@
         },
         {
             "domain": "Tracing",
-            "experimental": true,
             "dependencies": [
                 "IO"
             ],
@@ -19511,6 +23915,7 @@
                 {
                     "id": "MemoryDumpConfig",
                     "description": "Configuration for memory dump. Used only when \"memory-infra\" category is enabled.",
+                    "experimental": true,
                     "type": "object"
                 },
                 {
@@ -19520,6 +23925,7 @@
                         {
                             "name": "recordMode",
                             "description": "Controls how the trace buffer stores data.",
+                            "experimental": true,
                             "optional": true,
                             "type": "string",
                             "enum": [
@@ -19530,20 +23936,30 @@
                             ]
                         },
                         {
+                            "name": "traceBufferSizeInKb",
+                            "description": "Size of the trace buffer in kilobytes. If not specified or zero is passed, a default value\nof 200 MB would be used.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "number"
+                        },
+                        {
                             "name": "enableSampling",
                             "description": "Turns on JavaScript stack sampling.",
+                            "experimental": true,
                             "optional": true,
                             "type": "boolean"
                         },
                         {
                             "name": "enableSystrace",
                             "description": "Turns on system tracing.",
+                            "experimental": true,
                             "optional": true,
                             "type": "boolean"
                         },
                         {
                             "name": "enableArgumentFilter",
                             "description": "Turns on argument filter.",
+                            "experimental": true,
                             "optional": true,
                             "type": "boolean"
                         },
@@ -19568,6 +23984,7 @@
                         {
                             "name": "syntheticDelays",
                             "description": "Configuration to synthesize the delays in tracing.",
+                            "experimental": true,
                             "optional": true,
                             "type": "array",
                             "items": {
@@ -19577,6 +23994,7 @@
                         {
                             "name": "memoryDumpConfig",
                             "description": "Configuration for memory dump triggers. Used only when \"memory-infra\" category is enabled.",
+                            "experimental": true,
                             "optional": true,
                             "$ref": "MemoryDumpConfig"
                         }
@@ -19585,6 +24003,7 @@
                 {
                     "id": "StreamFormat",
                     "description": "Data format of a trace. Can be either the legacy JSON format or the\nprotocol buffer format. Note that the JSON format will be deprecated soon.",
+                    "experimental": true,
                     "type": "string",
                     "enum": [
                         "json",
@@ -19594,6 +24013,7 @@
                 {
                     "id": "StreamCompression",
                     "description": "Compression type to use for traces returned via streams.",
+                    "experimental": true,
                     "type": "string",
                     "enum": [
                         "none",
@@ -19603,6 +24023,7 @@
                 {
                     "id": "MemoryDumpLevelOfDetail",
                     "description": "Details exposed when memory request explicitly declared.\nKeep consistent with memory_dump_request_args.h and\nmemory_instrumentation.mojom",
+                    "experimental": true,
                     "type": "string",
                     "enum": [
                         "background",
@@ -19613,6 +24034,7 @@
                 {
                     "id": "TracingBackend",
                     "description": "Backend type to use for tracing. `chrome` uses the Chrome-integrated\ntracing service and is supported on all platforms. `system` is only\nsupported on Chrome OS and uses the Perfetto system tracing service.\n`auto` chooses `system` when the perfettoConfig provided to Tracing.start\nspecifies at least one non-Chrome data source; otherwise uses `chrome`.",
+                    "experimental": true,
                     "type": "string",
                     "enum": [
                         "auto",
@@ -19629,6 +24051,7 @@
                 {
                     "name": "getCategories",
                     "description": "Gets supported tracing categories.",
+                    "experimental": true,
                     "returns": [
                         {
                             "name": "categories",
@@ -19643,6 +24066,7 @@
                 {
                     "name": "recordClockSyncMarker",
                     "description": "Record a clock sync marker in the trace.",
+                    "experimental": true,
                     "parameters": [
                         {
                             "name": "syncId",
@@ -19654,6 +24078,7 @@
                 {
                     "name": "requestMemoryDump",
                     "description": "Request a global memory dump.",
+                    "experimental": true,
                     "parameters": [
                         {
                             "name": "deterministic",
@@ -19688,6 +24113,7 @@
                         {
                             "name": "categories",
                             "description": "Category/tag filter",
+                            "experimental": true,
                             "deprecated": true,
                             "optional": true,
                             "type": "string"
@@ -19695,6 +24121,7 @@
                         {
                             "name": "options",
                             "description": "Tracing options",
+                            "experimental": true,
                             "deprecated": true,
                             "optional": true,
                             "type": "string"
@@ -19702,6 +24129,7 @@
                         {
                             "name": "bufferUsageReportingInterval",
                             "description": "If set, the agent will issue bufferUsage events at this interval, specified in milliseconds",
+                            "experimental": true,
                             "optional": true,
                             "type": "number"
                         },
@@ -19724,6 +24152,7 @@
                         {
                             "name": "streamCompression",
                             "description": "Compression format to use. This only applies when using `ReturnAsStream`\ntransfer mode (defaults to `none`)",
+                            "experimental": true,
                             "optional": true,
                             "$ref": "StreamCompression"
                         },
@@ -19735,12 +24164,14 @@
                         {
                             "name": "perfettoConfig",
                             "description": "Base64-encoded serialized perfetto.protos.TraceConfig protobuf message\nWhen specified, the parameters `categories`, `options`, `traceConfig`\nare ignored. (Encoded as a base64 string when passed over JSON)",
+                            "experimental": true,
                             "optional": true,
                             "type": "string"
                         },
                         {
                             "name": "tracingBackend",
                             "description": "Backend type (defaults to `auto`)",
+                            "experimental": true,
                             "optional": true,
                             "$ref": "TracingBackend"
                         }
@@ -19750,6 +24181,7 @@
             "events": [
                 {
                     "name": "bufferUsage",
+                    "experimental": true,
                     "parameters": [
                         {
                             "name": "percentFull",
@@ -19773,7 +24205,8 @@
                 },
                 {
                     "name": "dataCollected",
-                    "description": "Contains an bucket of collected trace events. When tracing is stopped collected events will be\nsend as a sequence of dataCollected events followed by tracingComplete event.",
+                    "description": "Contains a bucket of collected trace events. When tracing is stopped collected events will be\nsent as a sequence of dataCollected events followed by tracingComplete event.",
+                    "experimental": true,
                     "parameters": [
                         {
                             "name": "value",
@@ -20053,7 +24486,7 @@
                         },
                         {
                             "name": "headers",
-                            "description": "If set, overrides the request headers.",
+                            "description": "If set, overrides the request headers. Note that the overrides do not\nextend to subsequent redirect hops, if a redirect happens. Another override\nmay be applied to a different request produced by a redirect.",
                             "optional": true,
                             "type": "array",
                             "items": {
@@ -20126,7 +24559,7 @@
                 },
                 {
                     "name": "getResponseBody",
-                    "description": "Causes the body of the response to be received from the server and\nreturned as a single string. May only be issued for a request that\nis paused in the Response stage and is mutually exclusive with\ntakeResponseBodyForInterceptionAsStream. Calling other methods that\naffect the request or disabling fetch domain before body is received\nresults in an undefined behavior.",
+                    "description": "Causes the body of the response to be received from the server and\nreturned as a single string. May only be issued for a request that\nis paused in the Response stage and is mutually exclusive with\ntakeResponseBodyForInterceptionAsStream. Calling other methods that\naffect the request or disabling fetch domain before body is received\nresults in an undefined behavior.\nNote that the response body is not available for redirects. Requests\npaused in the _redirect received_ state may be differentiated by\n`responseCode` and presence of `location` response header, see\ncomments to `requestPaused` for details.",
                     "parameters": [
                         {
                             "name": "requestId",
@@ -20167,7 +24600,7 @@
             "events": [
                 {
                     "name": "requestPaused",
-                    "description": "Issued when the domain is enabled and the request URL matches the\nspecified filter. The request is paused until the client responds\nwith one of continueRequest, failRequest or fulfillRequest.\nThe stage of the request can be determined by presence of responseErrorReason\nand responseStatusCode -- the request is at the response stage if either\nof these fields is present and in the request stage otherwise.",
+                    "description": "Issued when the domain is enabled and the request URL matches the\nspecified filter. The request is paused until the client responds\nwith one of continueRequest, failRequest or fulfillRequest.\nThe stage of the request can be determined by presence of responseErrorReason\nand responseStatusCode -- the request is at the response stage if either\nof these fields is present and in the request stage otherwise.\nRedirect responses and subsequent requests are reported similarly to regular\nresponses and requests. Redirect responses may be distinguished by the value\nof `responseStatusCode` (which is one of 301, 302, 303, 307, 308) along with\npresence of the `location` header. Requests resulting from a redirect will\nhave `redirectedRequestId` field set.",
                     "parameters": [
                         {
                             "name": "requestId",
@@ -20219,6 +24652,13 @@
                         {
                             "name": "networkId",
                             "description": "If the intercepted request had a corresponding Network.requestWillBeSent event fired for it,\nthen this networkId will be the same as the requestId present in the requestWillBeSent event.",
+                            "optional": true,
+                            "$ref": "Network.RequestId"
+                        },
+                        {
+                            "name": "redirectedRequestId",
+                            "description": "If the request is due to a redirect response from the server, the id of the request that\nhas caused the redirect.",
+                            "experimental": true,
                             "optional": true,
                             "$ref": "RequestId"
                         }
@@ -20800,6 +25240,18 @@
                             "type": "boolean"
                         },
                         {
+                            "name": "hasMinPinLength",
+                            "description": "If set to true, the authenticator will support the minPinLength extension.\nhttps://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-minpinlength-extension\nDefaults to false.",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "hasPrf",
+                            "description": "If set to true, the authenticator will support the prf extension.\nhttps://w3c.github.io/webauthn/#prf-extension\nDefaults to false.",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
                             "name": "automaticPresenceSimulation",
                             "description": "If set to true, tests of user presence will succeed immediately.\nOtherwise, they will not be resolved. Defaults to true.",
                             "optional": true,
@@ -20808,6 +25260,18 @@
                         {
                             "name": "isUserVerified",
                             "description": "Sets whether User Verification succeeds or fails for an authenticator.\nDefaults to false.",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "defaultBackupEligibility",
+                            "description": "Credentials created by this authenticator will have the backup\neligibility (BE) flag set to this value. Defaults to false.\nhttps://w3c.github.io/webauthn/#sctn-credential-backup",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "defaultBackupState",
+                            "description": "Credentials created by this authenticator will have the backup state\n(BS) flag set to this value. Defaults to false.\nhttps://w3c.github.io/webauthn/#sctn-credential-backup",
                             "optional": true,
                             "type": "boolean"
                         }
@@ -20852,6 +25316,18 @@
                             "description": "The large blob associated with the credential.\nSee https://w3c.github.io/webauthn/#sctn-large-blob-extension (Encoded as a base64 string when passed over JSON)",
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "backupEligibility",
+                            "description": "Assertions returned by this credential will have the backup eligibility\n(BE) flag set to this value. Defaults to the authenticator's\ndefaultBackupEligibility value.",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "backupState",
+                            "description": "Assertions returned by this credential will have the backup state (BS)\nflag set to this value. Defaults to the authenticator's\ndefaultBackupState value.",
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ]
                 }
@@ -20859,7 +25335,15 @@
             "commands": [
                 {
                     "name": "enable",
-                    "description": "Enable the WebAuthn domain and start intercepting credential storage and\nretrieval with a virtual authenticator."
+                    "description": "Enable the WebAuthn domain and start intercepting credential storage and\nretrieval with a virtual authenticator.",
+                    "parameters": [
+                        {
+                            "name": "enableUI",
+                            "description": "Whether to enable the WebAuthn user interface. Enabling the UI is\nrecommended for debugging and demo purposes, as it is closer to the real\nexperience. Disabling the UI is recommended for automated testing.\nSupported at the embedder's discretion if UI is available.\nDefaults to false.",
+                            "optional": true,
+                            "type": "boolean"
+                        }
+                    ]
                 },
                 {
                     "name": "disable",
@@ -20878,6 +25362,34 @@
                         {
                             "name": "authenticatorId",
                             "$ref": "AuthenticatorId"
+                        }
+                    ]
+                },
+                {
+                    "name": "setResponseOverrideBits",
+                    "description": "Resets parameters isBogusSignature, isBadUV, isBadUP to false if they are not present.",
+                    "parameters": [
+                        {
+                            "name": "authenticatorId",
+                            "$ref": "AuthenticatorId"
+                        },
+                        {
+                            "name": "isBogusSignature",
+                            "description": "If isBogusSignature is set, overrides the signature in the authenticator response to be zero.\nDefaults to false.",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "isBadUV",
+                            "description": "If isBadUV is set, overrides the UV bit in the flags in the authenticator response to\nbe zero. Defaults to false.",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "isBadUP",
+                            "description": "If isBadUP is set, overrides the UP bit in the flags in the authenticator response to\nbe zero. Defaults to false.",
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ]
                 },
@@ -20995,6 +25507,60 @@
                             "type": "boolean"
                         }
                     ]
+                },
+                {
+                    "name": "setCredentialProperties",
+                    "description": "Allows setting credential properties.\nhttps://w3c.github.io/webauthn/#sctn-automation-set-credential-properties",
+                    "parameters": [
+                        {
+                            "name": "authenticatorId",
+                            "$ref": "AuthenticatorId"
+                        },
+                        {
+                            "name": "credentialId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "backupEligibility",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "backupState",
+                            "optional": true,
+                            "type": "boolean"
+                        }
+                    ]
+                }
+            ],
+            "events": [
+                {
+                    "name": "credentialAdded",
+                    "description": "Triggered when a credential is added to an authenticator.",
+                    "parameters": [
+                        {
+                            "name": "authenticatorId",
+                            "$ref": "AuthenticatorId"
+                        },
+                        {
+                            "name": "credential",
+                            "$ref": "Credential"
+                        }
+                    ]
+                },
+                {
+                    "name": "credentialAsserted",
+                    "description": "Triggered when a credential is used in a webauthn assertion.",
+                    "parameters": [
+                        {
+                            "name": "authenticatorId",
+                            "$ref": "AuthenticatorId"
+                        },
+                        {
+                            "name": "credential",
+                            "$ref": "Credential"
+                        }
+                    ]
                 }
             ]
         },
@@ -21065,22 +25631,54 @@
                     ]
                 },
                 {
+                    "id": "PlayerErrorSourceLocation",
+                    "description": "Represents logged source line numbers reported in an error.\nNOTE: file and line are from chromium c++ implementation code, not js.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "file",
+                            "type": "string"
+                        },
+                        {
+                            "name": "line",
+                            "type": "integer"
+                        }
+                    ]
+                },
+                {
                     "id": "PlayerError",
                     "description": "Corresponds to kMediaError",
                     "type": "object",
                     "properties": [
                         {
-                            "name": "type",
-                            "type": "string",
-                            "enum": [
-                                "pipeline_error",
-                                "media_error"
-                            ]
+                            "name": "errorType",
+                            "type": "string"
                         },
                         {
-                            "name": "errorCode",
-                            "description": "When this switches to using media::Status instead of PipelineStatus\nwe can remove \"errorCode\" and replace it with the fields from\na Status instance. This also seems like a duplicate of the error\nlevel enum - there is a todo bug to have that level removed and\nuse this instead. (crbug.com/1068454)",
-                            "type": "string"
+                            "name": "code",
+                            "description": "Code is the numeric enum entry for a specific set of error codes, such\nas PipelineStatusCodes in media/base/pipeline_status.h",
+                            "type": "integer"
+                        },
+                        {
+                            "name": "stack",
+                            "description": "A trace of where this error was caused / where it passed through.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "PlayerErrorSourceLocation"
+                            }
+                        },
+                        {
+                            "name": "cause",
+                            "description": "Errors potentially have a root cause error, ie, a DecoderError might be\ncaused by an WindowsError",
+                            "type": "array",
+                            "items": {
+                                "$ref": "PlayerError"
+                            }
+                        },
+                        {
+                            "name": "data",
+                            "description": "Extra data attached to an error, such as an HRESULT, Video Codec, etc.",
+                            "type": "object"
                         }
                     ]
                 }
@@ -21176,6 +25774,916 @@
                 {
                     "name": "disable",
                     "description": "Disables the Media domain."
+                }
+            ]
+        },
+        {
+            "domain": "DeviceAccess",
+            "experimental": true,
+            "types": [
+                {
+                    "id": "RequestId",
+                    "description": "Device request id.",
+                    "type": "string"
+                },
+                {
+                    "id": "DeviceId",
+                    "description": "A device id.",
+                    "type": "string"
+                },
+                {
+                    "id": "PromptDevice",
+                    "description": "Device information displayed in a user prompt to select a device.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "id",
+                            "$ref": "DeviceId"
+                        },
+                        {
+                            "name": "name",
+                            "description": "Display name as it appears in a device request user prompt.",
+                            "type": "string"
+                        }
+                    ]
+                }
+            ],
+            "commands": [
+                {
+                    "name": "enable",
+                    "description": "Enable events in this domain."
+                },
+                {
+                    "name": "disable",
+                    "description": "Disable events in this domain."
+                },
+                {
+                    "name": "selectPrompt",
+                    "description": "Select a device in response to a DeviceAccess.deviceRequestPrompted event.",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "$ref": "RequestId"
+                        },
+                        {
+                            "name": "deviceId",
+                            "$ref": "DeviceId"
+                        }
+                    ]
+                },
+                {
+                    "name": "cancelPrompt",
+                    "description": "Cancel a prompt in response to a DeviceAccess.deviceRequestPrompted event.",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "$ref": "RequestId"
+                        }
+                    ]
+                }
+            ],
+            "events": [
+                {
+                    "name": "deviceRequestPrompted",
+                    "description": "A device request opened a user prompt to select a device. Respond with the\nselectPrompt or cancelPrompt command.",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "$ref": "RequestId"
+                        },
+                        {
+                            "name": "devices",
+                            "type": "array",
+                            "items": {
+                                "$ref": "PromptDevice"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "domain": "Preload",
+            "experimental": true,
+            "types": [
+                {
+                    "id": "RuleSetId",
+                    "description": "Unique id",
+                    "type": "string"
+                },
+                {
+                    "id": "RuleSet",
+                    "description": "Corresponds to SpeculationRuleSet",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "id",
+                            "$ref": "RuleSetId"
+                        },
+                        {
+                            "name": "loaderId",
+                            "description": "Identifies a document which the rule set is associated with.",
+                            "$ref": "Network.LoaderId"
+                        },
+                        {
+                            "name": "sourceText",
+                            "description": "Source text of JSON representing the rule set. If it comes from\n`<script>` tag, it is the textContent of the node. Note that it is\na JSON for valid case.\n\nSee also:\n- https://wicg.github.io/nav-speculation/speculation-rules.html\n- https://github.com/WICG/nav-speculation/blob/main/triggers.md",
+                            "type": "string"
+                        },
+                        {
+                            "name": "backendNodeId",
+                            "description": "A speculation rule set is either added through an inline\n`<script>` tag or through an external resource via the\n'Speculation-Rules' HTTP header. For the first case, we include\nthe BackendNodeId of the relevant `<script>` tag. For the second\ncase, we include the external URL where the rule set was loaded\nfrom, and also RequestId if Network domain is enabled.\n\nSee also:\n- https://wicg.github.io/nav-speculation/speculation-rules.html#speculation-rules-script\n- https://wicg.github.io/nav-speculation/speculation-rules.html#speculation-rules-header",
+                            "optional": true,
+                            "$ref": "DOM.BackendNodeId"
+                        },
+                        {
+                            "name": "url",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "requestId",
+                            "optional": true,
+                            "$ref": "Network.RequestId"
+                        },
+                        {
+                            "name": "errorType",
+                            "description": "Error information\n`errorMessage` is null iff `errorType` is null.",
+                            "optional": true,
+                            "$ref": "RuleSetErrorType"
+                        },
+                        {
+                            "name": "errorMessage",
+                            "description": "TODO(https://crbug.com/1425354): Replace this property with structured error.",
+                            "deprecated": true,
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "RuleSetErrorType",
+                    "type": "string",
+                    "enum": [
+                        "SourceIsNotJsonObject",
+                        "InvalidRulesSkipped"
+                    ]
+                },
+                {
+                    "id": "SpeculationAction",
+                    "description": "The type of preloading attempted. It corresponds to\nmojom::SpeculationAction (although PrefetchWithSubresources is omitted as it\nisn't being used by clients).",
+                    "type": "string",
+                    "enum": [
+                        "Prefetch",
+                        "Prerender"
+                    ]
+                },
+                {
+                    "id": "SpeculationTargetHint",
+                    "description": "Corresponds to mojom::SpeculationTargetHint.\nSee https://github.com/WICG/nav-speculation/blob/main/triggers.md#window-name-targeting-hints",
+                    "type": "string",
+                    "enum": [
+                        "Blank",
+                        "Self"
+                    ]
+                },
+                {
+                    "id": "PreloadingAttemptKey",
+                    "description": "A key that identifies a preloading attempt.\n\nThe url used is the url specified by the trigger (i.e. the initial URL), and\nnot the final url that is navigated to. For example, prerendering allows\nsame-origin main frame navigations during the attempt, but the attempt is\nstill keyed with the initial URL.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "loaderId",
+                            "$ref": "Network.LoaderId"
+                        },
+                        {
+                            "name": "action",
+                            "$ref": "SpeculationAction"
+                        },
+                        {
+                            "name": "url",
+                            "type": "string"
+                        },
+                        {
+                            "name": "targetHint",
+                            "optional": true,
+                            "$ref": "SpeculationTargetHint"
+                        }
+                    ]
+                },
+                {
+                    "id": "PreloadingAttemptSource",
+                    "description": "Lists sources for a preloading attempt, specifically the ids of rule sets\nthat had a speculation rule that triggered the attempt, and the\nBackendNodeIds of <a href> or <area href> elements that triggered the\nattempt (in the case of attempts triggered by a document rule). It is\npossible for multiple rule sets and links to trigger a single attempt.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "key",
+                            "$ref": "PreloadingAttemptKey"
+                        },
+                        {
+                            "name": "ruleSetIds",
+                            "type": "array",
+                            "items": {
+                                "$ref": "RuleSetId"
+                            }
+                        },
+                        {
+                            "name": "nodeIds",
+                            "type": "array",
+                            "items": {
+                                "$ref": "DOM.BackendNodeId"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "PrerenderFinalStatus",
+                    "description": "List of FinalStatus reasons for Prerender2.",
+                    "type": "string",
+                    "enum": [
+                        "Activated",
+                        "Destroyed",
+                        "LowEndDevice",
+                        "InvalidSchemeRedirect",
+                        "InvalidSchemeNavigation",
+                        "NavigationRequestBlockedByCsp",
+                        "MainFrameNavigation",
+                        "MojoBinderPolicy",
+                        "RendererProcessCrashed",
+                        "RendererProcessKilled",
+                        "Download",
+                        "TriggerDestroyed",
+                        "NavigationNotCommitted",
+                        "NavigationBadHttpStatus",
+                        "ClientCertRequested",
+                        "NavigationRequestNetworkError",
+                        "CancelAllHostsForTesting",
+                        "DidFailLoad",
+                        "Stop",
+                        "SslCertificateError",
+                        "LoginAuthRequested",
+                        "UaChangeRequiresReload",
+                        "BlockedByClient",
+                        "AudioOutputDeviceRequested",
+                        "MixedContent",
+                        "TriggerBackgrounded",
+                        "MemoryLimitExceeded",
+                        "DataSaverEnabled",
+                        "TriggerUrlHasEffectiveUrl",
+                        "ActivatedBeforeStarted",
+                        "InactivePageRestriction",
+                        "StartFailed",
+                        "TimeoutBackgrounded",
+                        "CrossSiteRedirectInInitialNavigation",
+                        "CrossSiteNavigationInInitialNavigation",
+                        "SameSiteCrossOriginRedirectNotOptInInInitialNavigation",
+                        "SameSiteCrossOriginNavigationNotOptInInInitialNavigation",
+                        "ActivationNavigationParameterMismatch",
+                        "ActivatedInBackground",
+                        "EmbedderHostDisallowed",
+                        "ActivationNavigationDestroyedBeforeSuccess",
+                        "TabClosedByUserGesture",
+                        "TabClosedWithoutUserGesture",
+                        "PrimaryMainFrameRendererProcessCrashed",
+                        "PrimaryMainFrameRendererProcessKilled",
+                        "ActivationFramePolicyNotCompatible",
+                        "PreloadingDisabled",
+                        "BatterySaverEnabled",
+                        "ActivatedDuringMainFrameNavigation",
+                        "PreloadingUnsupportedByWebContents",
+                        "CrossSiteRedirectInMainFrameNavigation",
+                        "CrossSiteNavigationInMainFrameNavigation",
+                        "SameSiteCrossOriginRedirectNotOptInInMainFrameNavigation",
+                        "SameSiteCrossOriginNavigationNotOptInInMainFrameNavigation",
+                        "MemoryPressureOnTrigger",
+                        "MemoryPressureAfterTriggered",
+                        "PrerenderingDisabledByDevTools",
+                        "SpeculationRuleRemoved",
+                        "ActivatedWithAuxiliaryBrowsingContexts",
+                        "MaxNumOfRunningEagerPrerendersExceeded",
+                        "MaxNumOfRunningNonEagerPrerendersExceeded",
+                        "MaxNumOfRunningEmbedderPrerendersExceeded",
+                        "PrerenderingUrlHasEffectiveUrl",
+                        "RedirectedPrerenderingUrlHasEffectiveUrl",
+                        "ActivationUrlHasEffectiveUrl",
+                        "JavaScriptInterfaceAdded",
+                        "JavaScriptInterfaceRemoved",
+                        "AllPrerenderingCanceled",
+                        "WindowClosed",
+                        "SlowNetwork",
+                        "OtherPrerenderedPageActivated"
+                    ]
+                },
+                {
+                    "id": "PreloadingStatus",
+                    "description": "Preloading status values, see also PreloadingTriggeringOutcome. This\nstatus is shared by prefetchStatusUpdated and prerenderStatusUpdated.",
+                    "type": "string",
+                    "enum": [
+                        "Pending",
+                        "Running",
+                        "Ready",
+                        "Success",
+                        "Failure",
+                        "NotSupported"
+                    ]
+                },
+                {
+                    "id": "PrefetchStatus",
+                    "description": "TODO(https://crbug.com/1384419): revisit the list of PrefetchStatus and\nfilter out the ones that aren't necessary to the developers.",
+                    "type": "string",
+                    "enum": [
+                        "PrefetchAllowed",
+                        "PrefetchFailedIneligibleRedirect",
+                        "PrefetchFailedInvalidRedirect",
+                        "PrefetchFailedMIMENotSupported",
+                        "PrefetchFailedNetError",
+                        "PrefetchFailedNon2XX",
+                        "PrefetchFailedPerPageLimitExceeded",
+                        "PrefetchEvictedAfterCandidateRemoved",
+                        "PrefetchEvictedForNewerPrefetch",
+                        "PrefetchHeldback",
+                        "PrefetchIneligibleRetryAfter",
+                        "PrefetchIsPrivacyDecoy",
+                        "PrefetchIsStale",
+                        "PrefetchNotEligibleBrowserContextOffTheRecord",
+                        "PrefetchNotEligibleDataSaverEnabled",
+                        "PrefetchNotEligibleExistingProxy",
+                        "PrefetchNotEligibleHostIsNonUnique",
+                        "PrefetchNotEligibleNonDefaultStoragePartition",
+                        "PrefetchNotEligibleSameSiteCrossOriginPrefetchRequiredProxy",
+                        "PrefetchNotEligibleSchemeIsNotHttps",
+                        "PrefetchNotEligibleUserHasCookies",
+                        "PrefetchNotEligibleUserHasServiceWorker",
+                        "PrefetchNotEligibleBatterySaverEnabled",
+                        "PrefetchNotEligiblePreloadingDisabled",
+                        "PrefetchNotFinishedInTime",
+                        "PrefetchNotStarted",
+                        "PrefetchNotUsedCookiesChanged",
+                        "PrefetchProxyNotAvailable",
+                        "PrefetchResponseUsed",
+                        "PrefetchSuccessfulButNotUsed",
+                        "PrefetchNotUsedProbeFailed"
+                    ]
+                },
+                {
+                    "id": "PrerenderMismatchedHeaders",
+                    "description": "Information of headers to be displayed when the header mismatch occurred.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "headerName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "initialValue",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "activationValue",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                }
+            ],
+            "commands": [
+                {
+                    "name": "enable"
+                },
+                {
+                    "name": "disable"
+                }
+            ],
+            "events": [
+                {
+                    "name": "ruleSetUpdated",
+                    "description": "Upsert. Currently, it is only emitted when a rule set added.",
+                    "parameters": [
+                        {
+                            "name": "ruleSet",
+                            "$ref": "RuleSet"
+                        }
+                    ]
+                },
+                {
+                    "name": "ruleSetRemoved",
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "$ref": "RuleSetId"
+                        }
+                    ]
+                },
+                {
+                    "name": "preloadEnabledStateUpdated",
+                    "description": "Fired when a preload enabled state is updated.",
+                    "parameters": [
+                        {
+                            "name": "disabledByPreference",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "disabledByDataSaver",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "disabledByBatterySaver",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "disabledByHoldbackPrefetchSpeculationRules",
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "disabledByHoldbackPrerenderSpeculationRules",
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "name": "prefetchStatusUpdated",
+                    "description": "Fired when a prefetch attempt is updated.",
+                    "parameters": [
+                        {
+                            "name": "key",
+                            "$ref": "PreloadingAttemptKey"
+                        },
+                        {
+                            "name": "initiatingFrameId",
+                            "description": "The frame id of the frame initiating prefetch.",
+                            "$ref": "Page.FrameId"
+                        },
+                        {
+                            "name": "prefetchUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "status",
+                            "$ref": "PreloadingStatus"
+                        },
+                        {
+                            "name": "prefetchStatus",
+                            "$ref": "PrefetchStatus"
+                        },
+                        {
+                            "name": "requestId",
+                            "$ref": "Network.RequestId"
+                        }
+                    ]
+                },
+                {
+                    "name": "prerenderStatusUpdated",
+                    "description": "Fired when a prerender attempt is updated.",
+                    "parameters": [
+                        {
+                            "name": "key",
+                            "$ref": "PreloadingAttemptKey"
+                        },
+                        {
+                            "name": "status",
+                            "$ref": "PreloadingStatus"
+                        },
+                        {
+                            "name": "prerenderStatus",
+                            "optional": true,
+                            "$ref": "PrerenderFinalStatus"
+                        },
+                        {
+                            "name": "disallowedMojoInterface",
+                            "description": "This is used to give users more information about the name of Mojo interface\nthat is incompatible with prerender and has caused the cancellation of the attempt.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "mismatchedHeaders",
+                            "optional": true,
+                            "type": "array",
+                            "items": {
+                                "$ref": "PrerenderMismatchedHeaders"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "preloadingAttemptSourcesUpdated",
+                    "description": "Send a list of sources for all preloading attempts in a document.",
+                    "parameters": [
+                        {
+                            "name": "loaderId",
+                            "$ref": "Network.LoaderId"
+                        },
+                        {
+                            "name": "preloadingAttemptSources",
+                            "type": "array",
+                            "items": {
+                                "$ref": "PreloadingAttemptSource"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "domain": "FedCm",
+            "description": "This domain allows interacting with the FedCM dialog.",
+            "experimental": true,
+            "types": [
+                {
+                    "id": "LoginState",
+                    "description": "Whether this is a sign-up or sign-in action for this account, i.e.\nwhether this account has ever been used to sign in to this RP before.",
+                    "type": "string",
+                    "enum": [
+                        "SignIn",
+                        "SignUp"
+                    ]
+                },
+                {
+                    "id": "DialogType",
+                    "description": "The types of FedCM dialogs.",
+                    "type": "string",
+                    "enum": [
+                        "AccountChooser",
+                        "AutoReauthn",
+                        "ConfirmIdpLogin",
+                        "Error"
+                    ]
+                },
+                {
+                    "id": "DialogButton",
+                    "description": "The buttons on the FedCM dialog.",
+                    "type": "string",
+                    "enum": [
+                        "ConfirmIdpLoginContinue",
+                        "ErrorGotIt",
+                        "ErrorMoreDetails"
+                    ]
+                },
+                {
+                    "id": "AccountUrlType",
+                    "description": "The URLs that each account has",
+                    "type": "string",
+                    "enum": [
+                        "TermsOfService",
+                        "PrivacyPolicy"
+                    ]
+                },
+                {
+                    "id": "Account",
+                    "description": "Corresponds to IdentityRequestAccount",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "accountId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "email",
+                            "type": "string"
+                        },
+                        {
+                            "name": "name",
+                            "type": "string"
+                        },
+                        {
+                            "name": "givenName",
+                            "type": "string"
+                        },
+                        {
+                            "name": "pictureUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "idpConfigUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "idpLoginUrl",
+                            "type": "string"
+                        },
+                        {
+                            "name": "loginState",
+                            "$ref": "LoginState"
+                        },
+                        {
+                            "name": "termsOfServiceUrl",
+                            "description": "These two are only set if the loginState is signUp",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "privacyPolicyUrl",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                }
+            ],
+            "events": [
+                {
+                    "name": "dialogShown",
+                    "parameters": [
+                        {
+                            "name": "dialogId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "dialogType",
+                            "$ref": "DialogType"
+                        },
+                        {
+                            "name": "accounts",
+                            "type": "array",
+                            "items": {
+                                "$ref": "Account"
+                            }
+                        },
+                        {
+                            "name": "title",
+                            "description": "These exist primarily so that the caller can verify the\nRP context was used appropriately.",
+                            "type": "string"
+                        },
+                        {
+                            "name": "subtitle",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "dialogClosed",
+                    "description": "Triggered when a dialog is closed, either by user action, JS abort,\nor a command below.",
+                    "parameters": [
+                        {
+                            "name": "dialogId",
+                            "type": "string"
+                        }
+                    ]
+                }
+            ],
+            "commands": [
+                {
+                    "name": "enable",
+                    "parameters": [
+                        {
+                            "name": "disableRejectionDelay",
+                            "description": "Allows callers to disable the promise rejection delay that would\nnormally happen, if this is unimportant to what's being tested.\n(step 4 of https://fedidcg.github.io/FedCM/#browser-api-rp-sign-in)",
+                            "optional": true,
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "name": "disable"
+                },
+                {
+                    "name": "selectAccount",
+                    "parameters": [
+                        {
+                            "name": "dialogId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "accountIndex",
+                            "type": "integer"
+                        }
+                    ]
+                },
+                {
+                    "name": "clickDialogButton",
+                    "parameters": [
+                        {
+                            "name": "dialogId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "dialogButton",
+                            "$ref": "DialogButton"
+                        }
+                    ]
+                },
+                {
+                    "name": "openUrl",
+                    "parameters": [
+                        {
+                            "name": "dialogId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "accountIndex",
+                            "type": "integer"
+                        },
+                        {
+                            "name": "accountUrlType",
+                            "$ref": "AccountUrlType"
+                        }
+                    ]
+                },
+                {
+                    "name": "dismissDialog",
+                    "parameters": [
+                        {
+                            "name": "dialogId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "triggerCooldown",
+                            "optional": true,
+                            "type": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "name": "resetCooldown",
+                    "description": "Resets the cooldown time, if any, to allow the next FedCM call to show\na dialog even if one was recently dismissed by the user."
+                }
+            ]
+        },
+        {
+            "domain": "PWA",
+            "description": "This domain allows interacting with the browser to control PWAs.",
+            "experimental": true,
+            "types": [
+                {
+                    "id": "FileHandlerAccept",
+                    "description": "The following types are the replica of\nhttps://crsrc.org/c/chrome/browser/web_applications/proto/web_app_os_integration_state.proto;drc=9910d3be894c8f142c977ba1023f30a656bc13fc;l=67",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "mediaType",
+                            "description": "New name of the mimetype according to\nhttps://www.iana.org/assignments/media-types/media-types.xhtml",
+                            "type": "string"
+                        },
+                        {
+                            "name": "fileExtensions",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "FileHandler",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "action",
+                            "type": "string"
+                        },
+                        {
+                            "name": "accepts",
+                            "type": "array",
+                            "items": {
+                                "$ref": "FileHandlerAccept"
+                            }
+                        },
+                        {
+                            "name": "displayName",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "id": "DisplayMode",
+                    "description": "If user prefers opening the app in browser or an app window.",
+                    "type": "string",
+                    "enum": [
+                        "standalone",
+                        "browser"
+                    ]
+                }
+            ],
+            "commands": [
+                {
+                    "name": "getOsAppState",
+                    "description": "Returns the following OS state for the given manifest id.",
+                    "parameters": [
+                        {
+                            "name": "manifestId",
+                            "description": "The id from the webapp's manifest file, commonly it's the url of the\nsite installing the webapp. See\nhttps://web.dev/learn/pwa/web-app-manifest.",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "badgeCount",
+                            "type": "integer"
+                        },
+                        {
+                            "name": "fileHandlers",
+                            "type": "array",
+                            "items": {
+                                "$ref": "FileHandler"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "install",
+                    "description": "Installs the given manifest identity, optionally using the given install_url\nor IWA bundle location.\n\nTODO(crbug.com/337872319) Support IWA to meet the following specific\nrequirement.\nIWA-specific install description: If the manifest_id is isolated-app://,\ninstall_url_or_bundle_url is required, and can be either an http(s) URL or\nfile:// URL pointing to a signed web bundle (.swbn). The .swbn file's\nsigning key must correspond to manifest_id. If Chrome is not in IWA dev\nmode, the installation will fail, regardless of the state of the allowlist.",
+                    "parameters": [
+                        {
+                            "name": "manifestId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "installUrlOrBundleUrl",
+                            "description": "The location of the app or bundle overriding the one derived from the\nmanifestId.",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "uninstall",
+                    "description": "Uninstalls the given manifest_id and closes any opened app windows.",
+                    "parameters": [
+                        {
+                            "name": "manifestId",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "launch",
+                    "description": "Launches the installed web app, or an url in the same web app instead of the\ndefault start url if it is provided. Returns a page Target.TargetID which\ncan be used to attach to via Target.attachToTarget or similar APIs.",
+                    "parameters": [
+                        {
+                            "name": "manifestId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "url",
+                            "optional": true,
+                            "type": "string"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "targetId",
+                            "description": "ID of the tab target created as a result.",
+                            "$ref": "Target.TargetID"
+                        }
+                    ]
+                },
+                {
+                    "name": "launchFilesInApp",
+                    "description": "Opens one or more local files from an installed web app identified by its\nmanifestId. The web app needs to have file handlers registered to process\nthe files. The API returns one or more page Target.TargetIDs which can be\nused to attach to via Target.attachToTarget or similar APIs.\nIf some files in the parameters cannot be handled by the web app, they will\nbe ignored. If none of the files can be handled, this API returns an error.\nIf no files are provided as the parameter, this API also returns an error.\n\nAccording to the definition of the file handlers in the manifest file, one\nTarget.TargetID may represent a page handling one or more files. The order\nof the returned Target.TargetIDs is not guaranteed.\n\nTODO(crbug.com/339454034): Check the existences of the input files.",
+                    "parameters": [
+                        {
+                            "name": "manifestId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "files",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "targetIds",
+                            "description": "IDs of the tab targets created as the result.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "Target.TargetID"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "openCurrentPageInApp",
+                    "description": "Opens the current page in its web app identified by the manifest id, needs\nto be called on a page target. This function returns immediately without\nwaiting for the app to finish loading.",
+                    "parameters": [
+                        {
+                            "name": "manifestId",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "changeAppUserSettings",
+                    "description": "Changes user settings of the web app identified by its manifestId. If the\napp was not installed, this command returns an error. Unset parameters will\nbe ignored; unrecognized values will cause an error.\n\nUnlike the ones defined in the manifest files of the web apps, these\nsettings are provided by the browser and controlled by the users, they\nimpact the way the browser handling the web apps.\n\nSee the comment of each parameter.",
+                    "parameters": [
+                        {
+                            "name": "manifestId",
+                            "type": "string"
+                        },
+                        {
+                            "name": "linkCapturing",
+                            "description": "If user allows the links clicked on by the user in the app's scope, or\nextended scope if the manifest has scope extensions and the flags\n`DesktopPWAsLinkCapturingWithScopeExtensions` and\n`WebAppEnableScopeExtensions` are enabled.\n\nNote, the API does not support resetting the linkCapturing to the\ninitial value, uninstalling and installing the web app again will reset\nit.\n\nTODO(crbug.com/339453269): Setting this value on ChromeOS is not\nsupported yet.",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "displayMode",
+                            "optional": true,
+                            "$ref": "DisplayMode"
+                        }
+                    ]
                 }
             ]
         }

--- a/json/js_protocol.json
+++ b/json/js_protocol.json
@@ -374,7 +374,6 @@
                             "description": "Type of the debug symbols.",
                             "type": "string",
                             "enum": [
-                                "None",
                                 "SourceMap",
                                 "EmbeddedDWARF",
                                 "ExternalDWARF"
@@ -790,6 +789,21 @@
                     ]
                 },
                 {
+                    "name": "setBlackboxExecutionContexts",
+                    "description": "Replace previous blackbox execution contexts with passed ones. Forces backend to skip\nstepping/pausing in scripts in these execution contexts. VM will try to leave blackboxed script by\nperforming 'step in' several times, finally resorting to 'step out' if unsuccessful.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "uniqueIds",
+                            "description": "Array of execution context unique ids for the debugger to ignore.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
+                {
                     "name": "setBlackboxPatterns",
                     "description": "Replace previous blackbox patterns with passed ones. Forces backend to skip stepping/pausing in\nscripts with url matching one of the patterns. VM will try to leave blackboxed script by\nperforming 'step in' several times, finally resorting to 'step out' if unsuccessful.",
                     "experimental": true,
@@ -801,6 +815,12 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        {
+                            "name": "skipAnonymous",
+                            "description": "If true, also ignore scripts with no source url.",
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ]
                 },
@@ -1456,10 +1476,13 @@
                         },
                         {
                             "name": "debugSymbols",
-                            "description": "If the scriptLanguage is WebASsembly, the source of debug symbols for the module.",
+                            "description": "If the scriptLanguage is WebAssembly, the source of debug symbols for the module.",
                             "experimental": true,
                             "optional": true,
-                            "$ref": "Debugger.DebugSymbols"
+                            "type": "array",
+                            "items": {
+                                "$ref": "Debugger.DebugSymbols"
+                            }
                         },
                         {
                             "name": "embedderName",

--- a/json/js_protocol.json
+++ b/json/js_protocol.json
@@ -205,7 +205,8 @@
                         },
                         {
                             "name": "url",
-                            "description": "JavaScript script name or url.",
+                            "description": "JavaScript script name or url.\nDeprecated in favor of using the `location.scriptId` to resolve the URL via a previously\nsent `Debugger.scriptParsed` event.",
+                            "deprecated": true,
                             "type": "string"
                         },
                         {
@@ -226,6 +227,13 @@
                             "description": "The value being returned, if the function is at return point.",
                             "optional": true,
                             "$ref": "Runtime.RemoteObject"
+                        },
+                        {
+                            "name": "canBeRestarted",
+                            "description": "Valid only while the VM is paused and indicates whether this frame\ncan be restarted or not. Note that a `true` value here does not\nguarantee that Debugger#restartFrame with this CallFrameId will be\nsuccessful, but it is very likely.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ]
                 },
@@ -321,6 +329,29 @@
                                 "call",
                                 "return"
                             ]
+                        }
+                    ]
+                },
+                {
+                    "id": "WasmDisassemblyChunk",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "lines",
+                            "description": "The next chunk of disassembled lines.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "name": "bytecodeOffsets",
+                            "description": "The bytecode offsets describing the start of each line.",
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
                         }
                     ]
                 },
@@ -535,6 +566,61 @@
                     ]
                 },
                 {
+                    "name": "disassembleWasmModule",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "scriptId",
+                            "description": "Id of the script to disassemble",
+                            "$ref": "Runtime.ScriptId"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "streamId",
+                            "description": "For large modules, return a stream from which additional chunks of\ndisassembly can be read successively.",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "totalNumberOfLines",
+                            "description": "The total number of lines in the disassembly text.",
+                            "type": "integer"
+                        },
+                        {
+                            "name": "functionBodyOffsets",
+                            "description": "The offsets of all function bodies, in the format [start1, end1,\nstart2, end2, ...] where all ends are exclusive.",
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        {
+                            "name": "chunk",
+                            "description": "The first chunk of disassembly.",
+                            "$ref": "WasmDisassemblyChunk"
+                        }
+                    ]
+                },
+                {
+                    "name": "nextWasmDisassemblyChunk",
+                    "description": "Disassemble the next chunk of lines for the module corresponding to the\nstream. If disassembly is complete, this API will invalidate the streamId\nand return an empty chunk. Any subsequent calls for the now invalid stream\nwill return errors.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "streamId",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "chunk",
+                            "description": "The next chunk of disassembly.",
+                            "$ref": "WasmDisassemblyChunk"
+                        }
+                    ]
+                },
+                {
                     "name": "getWasmBytecode",
                     "description": "This command is deprecated. Use getScriptSource instead.",
                     "deprecated": true,
@@ -598,19 +684,29 @@
                 },
                 {
                     "name": "restartFrame",
-                    "description": "Restarts particular call frame from the beginning.",
-                    "deprecated": true,
+                    "description": "Restarts particular call frame from the beginning. The old, deprecated\nbehavior of `restartFrame` is to stay paused and allow further CDP commands\nafter a restart was scheduled. This can cause problems with restarting, so\nwe now continue execution immediatly after it has been scheduled until we\nreach the beginning of the restarted frame.\n\nTo stay back-wards compatible, `restartFrame` now expects a `mode`\nparameter to be present. If the `mode` parameter is missing, `restartFrame`\nerrors out.\n\nThe various return values are deprecated and `callFrames` is always empty.\nUse the call frames from the `Debugger#paused` events instead, that fires\nonce V8 pauses at the beginning of the restarted function.",
                     "parameters": [
                         {
                             "name": "callFrameId",
                             "description": "Call frame identifier to evaluate on.",
                             "$ref": "CallFrameId"
+                        },
+                        {
+                            "name": "mode",
+                            "description": "The `mode` parameter must be present and set to 'StepInto', otherwise\n`restartFrame` will error out.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "string",
+                            "enum": [
+                                "StepInto"
+                            ]
                         }
                     ],
                     "returns": [
                         {
                             "name": "callFrames",
                             "description": "New stack trace.",
+                            "deprecated": true,
                             "type": "array",
                             "items": {
                                 "$ref": "CallFrame"
@@ -619,13 +715,14 @@
                         {
                             "name": "asyncStackTrace",
                             "description": "Async stack trace, if any.",
+                            "deprecated": true,
                             "optional": true,
                             "$ref": "Runtime.StackTrace"
                         },
                         {
                             "name": "asyncStackTraceId",
                             "description": "Async stack trace, if any.",
-                            "experimental": true,
+                            "deprecated": true,
                             "optional": true,
                             "$ref": "Runtime.StackTraceId"
                         }
@@ -871,7 +968,7 @@
                 },
                 {
                     "name": "setPauseOnExceptions",
-                    "description": "Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or\nno exceptions. Initial pause on exceptions state is `none`.",
+                    "description": "Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions,\nor caught exceptions, no exceptions. Initial pause on exceptions state is `none`.",
                     "parameters": [
                         {
                             "name": "state",
@@ -879,6 +976,7 @@
                             "type": "string",
                             "enum": [
                                 "none",
+                                "caught",
                                 "uncaught",
                                 "all"
                             ]
@@ -899,7 +997,7 @@
                 },
                 {
                     "name": "setScriptSource",
-                    "description": "Edits JavaScript source live.",
+                    "description": "Edits JavaScript source live.\n\nIn general, functions that are currently on the stack can not be edited with\na single exception: If the edited function is the top-most stack frame and\nthat is the only activation of that function on the stack. In this case\nthe live edit will be successful and a `Debugger.restartFrame` for the\ntop-most function is automatically triggered.",
                     "parameters": [
                         {
                             "name": "scriptId",
@@ -916,12 +1014,20 @@
                             "description": "If true the change will not actually be applied. Dry run may be used to get result\ndescription without actually modifying the code.",
                             "optional": true,
                             "type": "boolean"
+                        },
+                        {
+                            "name": "allowTopFrameEditing",
+                            "description": "If true, then `scriptSource` is allowed to change the function on top of the stack\nas long as the top-most stack frame is the only activation of that function.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ],
                     "returns": [
                         {
                             "name": "callFrames",
                             "description": "New stack trace in case editing has happened while VM was stopped.",
+                            "deprecated": true,
                             "optional": true,
                             "type": "array",
                             "items": {
@@ -931,25 +1037,40 @@
                         {
                             "name": "stackChanged",
                             "description": "Whether current call stack  was modified after applying the changes.",
+                            "deprecated": true,
                             "optional": true,
                             "type": "boolean"
                         },
                         {
                             "name": "asyncStackTrace",
                             "description": "Async stack trace, if any.",
+                            "deprecated": true,
                             "optional": true,
                             "$ref": "Runtime.StackTrace"
                         },
                         {
                             "name": "asyncStackTraceId",
                             "description": "Async stack trace, if any.",
-                            "experimental": true,
+                            "deprecated": true,
                             "optional": true,
                             "$ref": "Runtime.StackTraceId"
                         },
                         {
+                            "name": "status",
+                            "description": "Whether the operation was successful or not. Only `Ok` denotes a\nsuccessful live edit while the other enum variants denote why\nthe live edit failed.",
+                            "experimental": true,
+                            "type": "string",
+                            "enum": [
+                                "Ok",
+                                "CompileError",
+                                "BlockedByActiveGenerator",
+                                "BlockedByActiveFunction",
+                                "BlockedByTopLevelEsModuleChange"
+                            ]
+                        },
+                        {
                             "name": "exceptionDetails",
-                            "description": "Exception details if any.",
+                            "description": "Exception details if any. Only present when `status` is `CompileError`.",
                             "optional": true,
                             "$ref": "Runtime.ExceptionDetails"
                         }
@@ -1081,7 +1202,8 @@
                                 "OOM",
                                 "other",
                                 "promiseRejection",
-                                "XHR"
+                                "XHR",
+                                "step"
                             ]
                         },
                         {
@@ -1167,12 +1289,12 @@
                         },
                         {
                             "name": "hash",
-                            "description": "Content hash of the script.",
+                            "description": "Content hash of the script, SHA-256.",
                             "type": "string"
                         },
                         {
                             "name": "executionContextAuxData",
-                            "description": "Embedder-specific auxiliary data.",
+                            "description": "Embedder-specific auxiliary data likely matching {isDefault: boolean, type: 'default'|'isolated'|'worker', frameId: string}",
                             "optional": true,
                             "type": "object"
                         },
@@ -1271,12 +1393,12 @@
                         },
                         {
                             "name": "hash",
-                            "description": "Content hash of the script.",
+                            "description": "Content hash of the script, SHA-256.",
                             "type": "string"
                         },
                         {
                             "name": "executionContextAuxData",
-                            "description": "Embedder-specific auxiliary data.",
+                            "description": "Embedder-specific auxiliary data likely matching {isDefault: boolean, type: 'default'|'isolated'|'worker', frameId: string}",
                             "optional": true,
                             "type": "object"
                         },
@@ -1511,6 +1633,18 @@
                             "description": "Average sample interval in bytes. Poisson distribution is used for the intervals. The\ndefault value is 32768 bytes.",
                             "optional": true,
                             "type": "number"
+                        },
+                        {
+                            "name": "includeObjectsCollectedByMajorGC",
+                            "description": "By default, the sampling heap profiler reports only objects which are\nstill alive when the profile is returned via getSamplingProfile or\nstopSampling, which is useful for determining what functions contribute\nthe most to steady-state memory usage. This flag instructs the sampling\nheap profiler to also include information about objects discarded by\nmajor GC, which will show which functions cause large temporary memory\nusage or long GC pauses.",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "includeObjectsCollectedByMinorGC",
+                            "description": "By default, the sampling heap profiler reports only objects which are\nstill alive when the profile is returned via getSamplingProfile or\nstopSampling, which is useful for determining what functions contribute\nthe most to steady-state memory usage. This flag instructs the sampling\nheap profiler to also include information about objects discarded by\nminor GC, which is useful when tuning a latency-sensitive application\nfor minimal GC activity.",
+                            "optional": true,
+                            "type": "boolean"
                         }
                     ]
                 },
@@ -1545,12 +1679,21 @@
                         },
                         {
                             "name": "treatGlobalObjectsAsRoots",
+                            "description": "Deprecated in favor of `exposeInternals`.",
+                            "deprecated": true,
                             "optional": true,
                             "type": "boolean"
                         },
                         {
                             "name": "captureNumericValue",
                             "description": "If true, numerical values are included in the snapshot",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "exposeInternals",
+                            "description": "If true, exposes internals of the snapshot.",
+                            "experimental": true,
                             "optional": true,
                             "type": "boolean"
                         }
@@ -1567,13 +1710,21 @@
                         },
                         {
                             "name": "treatGlobalObjectsAsRoots",
-                            "description": "If true, a raw snapshot without artificial roots will be generated",
+                            "description": "If true, a raw snapshot without artificial roots will be generated.\nDeprecated in favor of `exposeInternals`.",
+                            "deprecated": true,
                             "optional": true,
                             "type": "boolean"
                         },
                         {
                             "name": "captureNumericValue",
                             "description": "If true, numerical values are included in the snapshot",
+                            "optional": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "exposeInternals",
+                            "description": "If true, exposes internals of the snapshot.",
+                            "experimental": true,
                             "optional": true,
                             "type": "boolean"
                         }
@@ -1826,66 +1977,6 @@
                             }
                         }
                     ]
-                },
-                {
-                    "id": "TypeObject",
-                    "description": "Describes a type collected during runtime.",
-                    "experimental": true,
-                    "type": "object",
-                    "properties": [
-                        {
-                            "name": "name",
-                            "description": "Name of a type collected with type profiling.",
-                            "type": "string"
-                        }
-                    ]
-                },
-                {
-                    "id": "TypeProfileEntry",
-                    "description": "Source offset and types for a parameter or return value.",
-                    "experimental": true,
-                    "type": "object",
-                    "properties": [
-                        {
-                            "name": "offset",
-                            "description": "Source offset of the parameter or end of function for return values.",
-                            "type": "integer"
-                        },
-                        {
-                            "name": "types",
-                            "description": "The types for this parameter or return value.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "TypeObject"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "id": "ScriptTypeProfile",
-                    "description": "Type profile data collected during runtime for a JavaScript script.",
-                    "experimental": true,
-                    "type": "object",
-                    "properties": [
-                        {
-                            "name": "scriptId",
-                            "description": "JavaScript script id.",
-                            "$ref": "Runtime.ScriptId"
-                        },
-                        {
-                            "name": "url",
-                            "description": "JavaScript script name or url.",
-                            "type": "string"
-                        },
-                        {
-                            "name": "entries",
-                            "description": "Type profile entries for parameters and return values of the functions in the script.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "TypeProfileEntry"
-                            }
-                        }
-                    ]
                 }
             ],
             "commands": [
@@ -1955,11 +2046,6 @@
                     ]
                 },
                 {
-                    "name": "startTypeProfile",
-                    "description": "Enable type profile.",
-                    "experimental": true
-                },
-                {
                     "name": "stop",
                     "returns": [
                         {
@@ -1972,11 +2058,6 @@
                 {
                     "name": "stopPreciseCoverage",
                     "description": "Disable precise code coverage. Disabling releases unnecessary execution count records and allows\nexecuting optimized code."
-                },
-                {
-                    "name": "stopTypeProfile",
-                    "description": "Disable type profile. Disabling releases type profile data collected so far.",
-                    "experimental": true
                 },
                 {
                     "name": "takePreciseCoverage",
@@ -1994,21 +2075,6 @@
                             "name": "timestamp",
                             "description": "Monotonically increasing time (in seconds) when the coverage update was taken in the backend.",
                             "type": "number"
-                        }
-                    ]
-                },
-                {
-                    "name": "takeTypeProfile",
-                    "description": "Collect type profile.",
-                    "experimental": true,
-                    "returns": [
-                        {
-                            "name": "result",
-                            "description": "Type profile for all scripts since startTypeProfile() was turned on.",
-                            "type": "array",
-                            "items": {
-                                "$ref": "ScriptTypeProfile"
-                            }
                         }
                     ]
                 }
@@ -2096,6 +2162,87 @@
                     "type": "string"
                 },
                 {
+                    "id": "SerializationOptions",
+                    "description": "Represents options for serialization. Overrides `generatePreview` and `returnByValue`.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "serialization",
+                            "type": "string",
+                            "enum": [
+                                "deep",
+                                "json",
+                                "idOnly"
+                            ]
+                        },
+                        {
+                            "name": "maxDepth",
+                            "description": "Deep serialization depth. Default is full depth. Respected only in `deep` serialization mode.",
+                            "optional": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "additionalParameters",
+                            "description": "Embedder-specific parameters. For example if connected to V8 in Chrome these control DOM\nserialization via `maxNodeDepth: integer` and `includeShadowTree: \"none\" | \"open\" | \"all\"`.\nValues can be only of type string or integer.",
+                            "optional": true,
+                            "type": "object"
+                        }
+                    ]
+                },
+                {
+                    "id": "DeepSerializedValue",
+                    "description": "Represents deep serialized value.",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "type",
+                            "type": "string",
+                            "enum": [
+                                "undefined",
+                                "null",
+                                "string",
+                                "number",
+                                "boolean",
+                                "bigint",
+                                "regexp",
+                                "date",
+                                "symbol",
+                                "array",
+                                "object",
+                                "function",
+                                "map",
+                                "set",
+                                "weakmap",
+                                "weakset",
+                                "error",
+                                "proxy",
+                                "promise",
+                                "typedarray",
+                                "arraybuffer",
+                                "node",
+                                "window",
+                                "generator"
+                            ]
+                        },
+                        {
+                            "name": "value",
+                            "optional": true,
+                            "type": "any"
+                        },
+                        {
+                            "name": "objectId",
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "weakLocalObjectReference",
+                            "description": "Set if value reference met more then once during serialization. In such\ncase, value is provided only to one of the serialized values. Unique\nper value in the scope of one CDP call.",
+                            "optional": true,
+                            "type": "integer"
+                        }
+                    ]
+                },
+                {
                     "id": "RemoteObjectId",
                     "description": "Unique object identifier.",
                     "type": "string"
@@ -2175,6 +2322,13 @@
                             "description": "String representation of the object.",
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "deepSerializedValue",
+                            "description": "Deep serialized value.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "DeepSerializedValue"
                         },
                         {
                             "name": "objectId",
@@ -2549,7 +2703,7 @@
                         },
                         {
                             "name": "auxData",
-                            "description": "Embedder-specific auxiliary data.",
+                            "description": "Embedder-specific auxiliary data likely matching {isDefault: boolean, type: 'default'|'isolated'|'worker', frameId: string}",
                             "optional": true,
                             "type": "object"
                         }
@@ -2788,7 +2942,7 @@
                         },
                         {
                             "name": "returnByValue",
-                            "description": "Whether the result is expected to be a JSON object which should be sent by value.",
+                            "description": "Whether the result is expected to be a JSON object which should be sent by value.\nCan be overriden by `serializationOptions`.",
                             "optional": true,
                             "type": "boolean"
                         },
@@ -2829,6 +2983,20 @@
                             "experimental": true,
                             "optional": true,
                             "type": "boolean"
+                        },
+                        {
+                            "name": "uniqueContextId",
+                            "description": "An alternative way to specify the execution context to call function on.\nCompared to contextId that may be reused across processes, this is guaranteed to be\nsystem-unique, so it can be used to prevent accidental function call\nin context different than intended (e.g. as a result of navigation across process\nboundaries).\nThis is mutually exclusive with `executionContextId`.",
+                            "experimental": true,
+                            "optional": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "serializationOptions",
+                            "description": "Specifies the result serialization. If provided, overrides\n`generatePreview` and `returnByValue`.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "SerializationOptions"
                         }
                     ],
                     "returns": [
@@ -2997,6 +3165,13 @@
                             "experimental": true,
                             "optional": true,
                             "type": "string"
+                        },
+                        {
+                            "name": "serializationOptions",
+                            "description": "Specifies the result serialization. If provided, overrides\n`generatePreview` and `returnByValue`.",
+                            "experimental": true,
+                            "optional": true,
+                            "$ref": "SerializationOptions"
                         }
                     ],
                     "returns": [
@@ -3291,7 +3466,6 @@
                 {
                     "name": "addBinding",
                     "description": "If executionContextId is empty, adds binding with the given name on the\nglobal objects of all inspected contexts, including those created later,\nbindings survive reloads.\nBinding function takes exactly one argument, this argument should be string,\nin case of any other input, function throws an exception.\nEach binding function call produces Runtime.bindingCalled notification.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "name",
@@ -3300,6 +3474,7 @@
                         {
                             "name": "executionContextId",
                             "description": "If specified, the binding would only be exposed to the specified\nexecution context. If omitted and `executionContextName` is not set,\nthe binding is exposed to all execution contexts of the target.\nThis parameter is mutually exclusive with `executionContextName`.\nDeprecated in favor of `executionContextName` due to an unclear use case\nand bugs in implementation (crbug.com/1169639). `executionContextId` will be\nremoved in the future.",
+                            "experimental": true,
                             "deprecated": true,
                             "optional": true,
                             "$ref": "ExecutionContextId"
@@ -3307,7 +3482,6 @@
                         {
                             "name": "executionContextName",
                             "description": "If specified, the binding is exposed to the executionContext with\nmatching name, even for contexts created after the binding is added.\nSee also `ExecutionContext.name` and `worldName` parameter to\n`Page.addScriptToEvaluateOnNewDocument`.\nThis parameter is mutually exclusive with `executionContextId`.",
-                            "experimental": true,
                             "optional": true,
                             "type": "string"
                         }
@@ -3316,11 +3490,29 @@
                 {
                     "name": "removeBinding",
                     "description": "This method does not remove binding function from global object but\nunsubscribes current runtime agent from Runtime.bindingCalled notifications.",
-                    "experimental": true,
                     "parameters": [
                         {
                             "name": "name",
                             "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "name": "getExceptionDetails",
+                    "description": "This method tries to lookup and populate exception details for a\nJavaScript Error object.\nNote that the stackTrace portion of the resulting exceptionDetails will\nonly be populated if the Runtime domain was enabled at the time when the\nError was thrown.",
+                    "experimental": true,
+                    "parameters": [
+                        {
+                            "name": "errorObjectId",
+                            "description": "The error object for which to resolve the exception details.",
+                            "$ref": "RemoteObjectId"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "exceptionDetails",
+                            "optional": true,
+                            "$ref": "ExceptionDetails"
                         }
                     ]
                 }
@@ -3457,7 +3649,14 @@
                         {
                             "name": "executionContextId",
                             "description": "Id of the destroyed context",
+                            "deprecated": true,
                             "$ref": "ExecutionContextId"
+                        },
+                        {
+                            "name": "executionContextUniqueId",
+                            "description": "Unique Id of the destroyed context",
+                            "experimental": true,
+                            "type": "string"
                         }
                     ]
                 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod compile;
 use crate::compile::compile_cdp_json;
 
 pub fn init() {
-    const CDP_COMMIT: &str = "62fe5c94750b18b955b1dd50c32e80764847a9c1";
+    const CDP_COMMIT: &str = "4f13107aac59fe418043f9edfdaef3b7da579614";
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let out_file = Path::new(&out_dir).join("protocol.rs");
     let mut file = OpenOptions::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod compile;
 use crate::compile::compile_cdp_json;
 
 pub fn init() {
-    const CDP_COMMIT: &str = "15f524c8f5ce5b317ddcdf5e6f875d6eb8bdac88";
+    const CDP_COMMIT: &str = "62fe5c94750b18b955b1dd50c32e80764847a9c1";
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let out_file = Path::new(&out_dir).join("protocol.rs");
     let mut file = OpenOptions::new()


### PR DESCRIPTION
This PR does the following
1.  Updates the cached CDP to [v0.0.1392070](https://github.com/ChromeDevTools/devtools-protocol/releases/tag/v0.0.1392070)
2. Renames `Self` struct elements to `CdpSelf` because Rust does not allow for`r#Self`. This only occurs in `Preload::SpeculationTargetHint`.
3. Adds return types to the imported dependencies. There was an issue with the generate protocol.rs where `pub mod PWA` did not import `super::Target`.  `LaunchReturnObject`  and `LaunchFilesInAppReturnObject` in `PWA` both use `Target`.